### PR TITLE
fix: Fix types for MapeoProject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@mapeo/core": "^9.0.0-alpha.1"
+        "@mapeo/core": "9.0.0-alpha.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@digidem/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-OoRFrUjPhUtfYTghpsn7CYl8ng0hoRIYAXmEKvCLMVxXOFFa/8SPrLIeS00J6Z7pfdKjRyeiKrDgqgo2NEiYYw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-pWFiP1Zj3U3LHa1FC87hBgFBF6HTeVWzSRy1P/IJO+ExMevQlIQMOwYvbcazqyGJJq0NxW0VsF+lPClzpllVcQ==",
       "dependencies": {
         "@types/node": "^18.16.19",
         "@types/streamx": "^2.9.1",
@@ -493,22 +493,21 @@
       "peer": true
     },
     "node_modules/@mapeo/core": {
-      "version": "9.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.1.tgz",
-      "integrity": "sha512-DDJoug2p4vKnyExla9BO9iWn0F6dlHbVUR3G+Dory+xD5xNYfpJhx9jSX1oe3IS6iKi56hdix3hI++YO4LJutA==",
+      "version": "9.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.4.tgz",
+      "integrity": "sha512-W6702jKm6mAwIFPwz+aeb8W1s6/kk5sEho3aheoQyibZSdmHpdalMEEWx0VJt05uHkSIQhmlWBQSEFGa9PAtyQ==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "@digidem/types": "^2.1.0",
+        "@digidem/types": "^2.2.0",
         "@fastify/type-provider-typebox": "^3.3.0",
         "@hyperswarm/secret-stream": "^6.1.2",
-        "@mapeo/crypto": "^1.0.0-alpha.8",
-        "@mapeo/schema": "^3.0.0-next.9",
-        "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
+        "@mapeo/crypto": "1.0.0-alpha.10",
+        "@mapeo/schema": "3.0.0-next.13",
+        "@mapeo/sqlite-indexer": "1.0.0-alpha.8",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
-        "base32.js": "^0.1.0",
-        "better-sqlite3": "^8.3.0",
+        "better-sqlite3": "^8.7.0",
         "big-sparse-array": "^1.0.3",
         "bogon": "^1.1.0",
         "bonjour-service": "^1.1.1",
@@ -516,37 +515,61 @@
         "corestore": "^6.8.4",
         "debug": "^4.3.4",
         "drizzle-orm": "0.28.2",
-        "eventemitter3": "^5.0.1",
+        "fastify": ">= 4",
         "fastify-plugin": "^4.5.0",
-        "hypercore": "^10.9.0",
-        "hypercore-crypto": "^3.3.1",
-        "hyperdrive": "^11.5.3",
-        "hyperswarm": "^4.4.1",
+        "hyperblobs": "2.3.0",
+        "hypercore": "10.17.0",
+        "hypercore-crypto": "3.4.0",
+        "hyperdrive": "11.5.3",
+        "hyperswarm": "4.4.1",
         "magic-bytes.js": "^1.0.14",
         "map-obj": "^5.0.2",
-        "multi-core-indexer": "^1.0.0-alpha.7",
+        "multi-core-indexer": "^1.0.0-alpha.9",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.1.2",
         "patch-package": "^8.0.0",
         "protobufjs": "^7.2.3",
         "protomux": "^3.4.1",
         "quickbit-universal": "^2.2.0",
-        "rpc-reflector": "^1.3.11",
         "sodium-universal": "^4.0.0",
         "start-stop-state-machine": "^1.2.0",
         "sub-encoder": "^2.1.1",
+        "throttle-debounce": "^5.0.0",
         "tiny-typed-emitter": "^2.1.0",
-        "varint": "^6.0.0",
-        "z32": "^1.0.1"
-      },
-      "peerDependencies": {
-        "fastify": ">= 4"
+        "type-fest": "^4.5.0",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/@mapeo/core/node_modules/hypercore": {
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.17.0.tgz",
+      "integrity": "sha512-Yp9lyfUjp81Gy1nPHemNFtYQtngliCGZ6prH+qxvjr2FPVG1QFtNqtOh+ZxFu4hXZ1dAOLYkQOA7Qq2vjFe64A==",
+      "peer": true,
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.0.0",
+        "b4a": "^1.1.0",
+        "big-sparse-array": "^1.0.3",
+        "compact-encoding": "^2.11.0",
+        "crc-universal": "^1.0.2",
+        "events": "^3.3.0",
+        "flat-tree": "^1.9.0",
+        "hypercore-crypto": "^3.2.1",
+        "is-options": "^1.0.1",
+        "protomux": "^3.4.0",
+        "quickbit-universal": "^2.1.1",
+        "random-access-file": "^4.0.0",
+        "random-array-iterator": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "sodium-universal": "^4.0.0",
+        "streamx": "^2.12.4",
+        "xache": "^1.1.0",
+        "z32": "^1.0.0"
       }
     },
     "node_modules/@mapeo/crypto": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@mapeo/crypto/-/crypto-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-2pIykZTFWINwtdsk2Fl3+3UdpQZrt1/IwMgvglwZlxyqKM7LpcuAda871BFiK1CcEsDlaTT63FBtIszEXnnawg==",
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@mapeo/crypto/-/crypto-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-TEK8HN1W0XZOOADIMxa4saXtqAZKyBDeVVn3RBCcPaCiOGHeYy43/0rMnBVTbXZCLsLVPnOXwv6vg+vUkasrWQ==",
       "dependencies": {
         "@types/b4a": "^1.6.0",
         "b4a": "^1.6.4",
@@ -556,33 +579,15 @@
         "compact-encoding-net": "^1.0.1",
         "compact-encoding-struct": "^1.2.0",
         "crc": "^3.8.0",
-        "derive-key": "^1.0.1",
         "lodash": "^4.17.21",
-        "sodium-universal": "^3.0.4",
+        "sodium-universal": "^4.0.0",
         "z32": "^1.0.0"
       }
     },
-    "node_modules/@mapeo/crypto/node_modules/sodium-universal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.1.0.tgz",
-      "integrity": "sha512-N2gxk68Kg2qZLSJ4h0NffEhp4BjgWHCHXVlDi1aG1hA3y+ZeWEmHqnpml8Hy47QzfL1xLy5nwr9LcsWAg2Ep0A==",
-      "dependencies": {
-        "blake2b": "^2.1.1",
-        "chacha20-universal": "^1.0.4",
-        "nanoassert": "^2.0.0",
-        "resolve": "^1.17.0",
-        "sha256-universal": "^1.1.0",
-        "sha512-universal": "^1.1.0",
-        "siphash24": "^1.0.1",
-        "sodium-javascript": "~0.8.0",
-        "sodium-native": "^3.2.0",
-        "xsalsa20": "^1.0.0"
-      }
-    },
     "node_modules/@mapeo/schema": {
-      "version": "3.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.9.tgz",
-      "integrity": "sha512-6ispOMPa5YvI5oAHxNzoqMX50jq5LPbEWyr87nAMRRlCRAtfzR1VcK/HMi5m46/S5178p8NHmPgvp6tT93vKCQ==",
+      "version": "3.0.0-next.13",
+      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.13.tgz",
+      "integrity": "sha512-g5+Lx0uGzq5i2nlrDvuPExkzrQpzx3dhl1G1gfXm72Hw8he2ecGOm5Gu9vW9PsfKtN45AKRy+jd7kfl9+jLhpw==",
       "peer": true,
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
@@ -642,9 +647,9 @@
       }
     },
     "node_modules/@mapeo/schema/node_modules/typedoc-plugin-markdown": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.16.0.tgz",
-      "integrity": "sha512-eeiC78fDNGFwemPIHiwRC+mEC7W5jwt3fceUev2gJ2nFnXpVHo8eRrpC9BLWZDee6ehnz/sPmNjizbXwpfaTBw==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
+      "integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
       "peer": true,
       "dependencies": {
         "handlebars": "^4.7.7"
@@ -667,9 +672,9 @@
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@mapeo/sqlite-indexer/-/sqlite-indexer-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-iLUePxr2kHgsWfFTuJAKjTSZCRuVsIVNbQVyLEkN0pX/2dWzljCxCRvO+9rc1x+bThUas96ZAzCedqeeqC0zRw==",
+      "version": "1.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@mapeo/sqlite-indexer/-/sqlite-indexer-1.0.0-alpha.8.tgz",
+      "integrity": "sha512-qU+I6L4QKp6CkNA5AYu8dqADWaX+usfZq89c+fKOmIRZ+jR9ta3790PzCQbr5VCaYPDfp0OfemO1EjJ7RhHfcQ==",
       "peer": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.4",
@@ -1134,9 +1139,9 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.6.0.tgz",
-      "integrity": "sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -1166,6 +1171,15 @@
       "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bits-to-bytes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bits-to-bytes/-/bits-to-bytes-1.3.0.tgz",
+      "integrity": "sha512-OJoHTpFXS9bXHBCekGTByf3MqM8CGblBDIduKQeeVVeiU9dDWywSSirXIBYGgg3d1zbVuvnMa1vD4r6PA0kOKg==",
+      "peer": true,
+      "dependencies": {
+        "b4a": "^1.5.0"
       }
     },
     "node_modules/bl": {
@@ -1202,15 +1216,6 @@
         "nanoassert": "^2.0.0"
       }
     },
-    "node_modules/blake2b-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/blake2b-universal/-/blake2b-universal-1.0.1.tgz",
-      "integrity": "sha512-vmMqpF8E9RCde8/+Su/s2rZRxOBwAYQsTyCgok4kLWhWrzMrX0CzID6pVheNJSESY0S0FNTOG4QfRJqnSLOjFA==",
-      "dependencies": {
-        "blake2b": "^2.1.3",
-        "sodium-native": "^3.0.1"
-      }
-    },
     "node_modules/blake2b-wasm": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
@@ -1218,6 +1223,21 @@
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blind-relay": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.3.1.tgz",
+      "integrity": "sha512-GNOCAQG76WvN8e1k4C8UyQgfpSl8h2NiUgr6aFQJY/WKISvsU1flG0o3TJoUGn5K9uvtbEUtdulgikS1aYKbAQ==",
+      "peer": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bits-to-bytes": "^1.3.0",
+        "compact-encoding": "^2.12.0",
+        "compact-encoding-bitfield": "^1.0.0",
+        "protomux": "^3.5.1",
+        "sodium-universal": "^4.0.0",
+        "streamx": "^2.15.1"
       }
     },
     "node_modules/bogon": {
@@ -1529,6 +1549,15 @@
       "integrity": "sha512-8eCZLmyBT4LtC90F/ekIqWos8Y7NaFxY75qa/SlSDVa95NVgMcibQb8z8MTeKb9zctemOJczSXMf5pwMqKjYEQ==",
       "dependencies": {
         "b4a": "^1.3.0"
+      }
+    },
+    "node_modules/compact-encoding-bitfield": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.0.0.tgz",
+      "integrity": "sha512-3nMVKUg+PF72UHfainmCL8uKvyWfxsjqOtUY+HiMPGLPCTjnwzoKfFAMo1Ad7nwTPdjBqtGK5b3BOFTFW4EBTg==",
+      "peer": true,
+      "dependencies": {
+        "compact-encoding": "^2.4.1"
       }
     },
     "node_modules/compact-encoding-net": {
@@ -2134,14 +2163,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/derive-key": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/derive-key/-/derive-key-1.0.1.tgz",
-      "integrity": "sha512-7DHGLGvxFF8umw8NEGH3n9KKgEN8duk4Fiy4WmN3QgNKEogDhaNIsTDd5JVN7ilB8xw4ike1Q08z8UJSJ7hebA==",
-      "dependencies": {
-        "blake2b-universal": "^1.0.0"
-      }
-    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -2170,9 +2191,9 @@
       }
     },
     "node_modules/dht-rpc": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.8.2.tgz",
-      "integrity": "sha512-r5/JXUOtvKJtdLmCKNj8YfX6os2074dbTlvu/eoHTV6WRRuB7dEb4+0TB5A0ATYGsLqUepEcCj6ZzRJollMFnw==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.10.1.tgz",
+      "integrity": "sha512-2Z3U1/8810g+8DgoUGfnOxga9f9Ntroh5W1YC0N4nWjrYCwNy8zYdbQhr1vTZGCSGI8wUMJ2jtq2T/JiZa6b5w==",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.1",
@@ -3007,6 +3028,34 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3057,7 +3106,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
@@ -3373,22 +3423,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/glob/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "peer": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -3399,18 +3433,6 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3514,6 +3536,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3620,9 +3643,9 @@
       }
     },
     "node_modules/hyperbee": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/hyperbee/-/hyperbee-2.15.1.tgz",
-      "integrity": "sha512-5lfnhCRh6hr1F7s+k08OEp2MIKwSo77jUS4NFxjyqlNDDoeUGvmTa/HLXgBzPEqgWiTA/cFq0gdL4qCY7XjPyw==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/hyperbee/-/hyperbee-2.18.1.tgz",
+      "integrity": "sha512-14wWv3qbu37hPN92e87kB3bo/f3irQXrzeuvHWyvLpvCiOEmyIX/I2lnTLPYdp5u8F7NwyL4V/F5eQ8o3C8Gpg==",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.0",
@@ -3637,13 +3660,12 @@
       }
     },
     "node_modules/hyperblobs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.3.3.tgz",
-      "integrity": "sha512-LErepXhOUuwnTBNloqYTaBLkdKTTOfG/jVazKlbkHMUVxA8x3U5XhOq9pHEHNkfFgsuj8SBLg5huO+DVEmbMCw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.3.0.tgz",
+      "integrity": "sha512-iBCLVEo6FK+Xd7cpLM3DQ6cTfuMmKPfDZNj5/JqKEgziBEuI0ZGGyMM5dqaVvtRX4s71y8BhrgsDi2p0pWdSmg==",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.1",
-        "hypercore-errors": "^1.0.0",
         "mutexify": "^1.4.0",
         "streamx": "^2.13.2"
       }
@@ -3705,24 +3727,26 @@
       }
     },
     "node_modules/hyperdht": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.6.2.tgz",
-      "integrity": "sha512-1qTaMu4e+vDcyaVE2sY3eWU9JLYtsFL5AZrjSUEKv02I7R4qtZeI7FDoDdY2e8tefgaTMxkLK75X5rUSu7WbKg==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.11.2.tgz",
+      "integrity": "sha512-4GVBDW5rNgtvkkfhkZydhL9dmrfv6lzmFV0mDdi5aPxF92FpzoSQYrTuZEnj1MJsNDOlmkLX7Tnquz5jqClG4A==",
       "peer": true,
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.3.1",
+        "blind-relay": "^1.3.0",
         "bogon": "^1.0.0",
         "compact-encoding": "^2.4.1",
         "compact-encoding-net": "^1.0.1",
         "debugging-stream": "^2.0.0",
-        "dht-rpc": "^6.7.0",
+        "dht-rpc": "^6.9.0",
         "events": "^3.3.0",
         "hypercore-crypto": "^3.3.0",
         "noise-curve-ed": "^2.0.0",
         "noise-handshake": "^3.0.0",
         "record-cache": "^1.1.1",
         "safety-catch": "^1.0.1",
+        "signal-promise": "^1.0.3",
         "sodium-universal": "^4.0.0",
         "xache": "^1.1.0"
       },
@@ -3731,9 +3755,9 @@
       }
     },
     "node_modules/hyperdrive": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-11.6.0.tgz",
-      "integrity": "sha512-QGY/ZQdr8XvhKMwh4rsJfcNY6Ehh4y6/QbsoRjMpGDaZ6OxpjdhvJZeFb0l2F6qPnI438j45+eu90pXKZR74KQ==",
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-11.5.3.tgz",
+      "integrity": "sha512-0542G6n9eAXK/+fl6bs+9rvxCrL/dQo9mZsbY+BFSCD3S6ymBlaVnjOCuQdNflYBOHFVNnbBYdDvZ9meInv+tw==",
       "peer": true,
       "dependencies": {
         "hyperbee": "^2.11.1",
@@ -3749,14 +3773,14 @@
       }
     },
     "node_modules/hyperswarm": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.6.1.tgz",
-      "integrity": "sha512-YhUe3HUCYcBCYruBCwk/uNViEy5f8bMnG87nCAeL45QLfH5Xck50TctoPlNfKf85J3Uyoy6txBtgfIJZQzVsNg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.4.1.tgz",
+      "integrity": "sha512-8VLR/DLx6BnZATdCoECwFWasz7tIVdxkwlALT25sV6GEERf2fwttkJrb+5BS9vht/fyXJ4l41x6YgDWCabIoiw==",
       "peer": true,
       "dependencies": {
         "b4a": "^1.3.1",
         "events": "^3.3.0",
-        "hyperdht": "^6.6.0",
+        "hyperdht": "^6.5.2",
         "safety-catch": "^1.0.2",
         "shuffled-priority-queue": "^2.1.0"
       }
@@ -3929,6 +3953,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
       "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -4611,9 +4636,9 @@
       "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "peer": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -4972,9 +4997,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5011,9 +5036,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multi-core-indexer": {
-      "version": "1.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/multi-core-indexer/-/multi-core-indexer-1.0.0-alpha.7.tgz",
-      "integrity": "sha512-+QR4YTwg1j+t2fN7O4mOYN373pOLb6YhxlPsblb1ENFU99LPQ3PdfRM/FSYUTOf3kMi8C69BRGivIPNCNxmZOw==",
+      "version": "1.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/multi-core-indexer/-/multi-core-indexer-1.0.0-alpha.9.tgz",
+      "integrity": "sha512-LopPO+BMy1UXyyDOXbDsJ6eXApo97riXnRqjL1LYwQ7+Q9oZlPWpRmyVY42+eApSt8Ub7AEcUjbl5yIszpffKQ==",
       "peer": true,
       "dependencies": {
         "@types/node": "^18.16.19",
@@ -5021,17 +5046,19 @@
         "b4a": "^1.6.4",
         "big-sparse-array": "^1.0.2",
         "debug": "^4.3.3",
-        "hypercore-crypto": "^3.4.0",
         "random-access-file": "^4.0.4",
         "streamx": "^2.15.0",
         "tiny-typed-emitter": "^2.1.0"
       }
     },
     "node_modules/multi-core-indexer/node_modules/@types/node": {
-      "version": "18.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
-      "peer": true
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -5666,7 +5693,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
@@ -6274,6 +6302,7 @@
       "version": "1.22.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
       "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -6680,9 +6709,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
-      "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "peer": true,
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
@@ -6719,6 +6748,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "peer": true
     },
     "node_modules/signed-varint": {
       "version": "2.0.1",
@@ -6864,15 +6899,6 @@
         "xsalsa20": "^1.0.0"
       }
     },
-    "node_modules/sodium-native": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.4.1.tgz",
-      "integrity": "sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
     "node_modules/sodium-secretstream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/sodium-secretstream/-/sodium-secretstream-1.1.0.tgz",
@@ -6887,7 +6913,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
       "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
-      "peer": true,
       "dependencies": {
         "blake2b": "^2.1.1",
         "chacha20-universal": "^1.0.4",
@@ -6905,7 +6930,6 @@
       "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
       "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.6.0"
       }
@@ -7330,9 +7354,9 @@
       }
     },
     "node_modules/sub-encoder": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sub-encoder/-/sub-encoder-2.1.1.tgz",
-      "integrity": "sha512-Xfza05u5b26tYB0uiTZLPvKis0gSf8VaX8IZNgtRSHzXiYW7SWHJe6vfRVP+wuK8GAqwhGJQwQ03E5HX7W5+YA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sub-encoder/-/sub-encoder-2.1.3.tgz",
+      "integrity": "sha512-Xxx04ygZo/1J3yHvaSA6VhDmiSaBQkw/PmO3YnnYFXle+tfOGToC6FcDpIfMztWZXJzuKG14b/57HMkiL58C6A==",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.0",
@@ -7354,6 +7378,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7425,6 +7450,15 @@
       "peer": true,
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/through": {
@@ -7549,9 +7583,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.2.tgz",
-      "integrity": "sha512-VpwuOgnTsQUUWi0id8Hl4/xiQ+OoaeJGe8dnFjzubJYe/lOc2/d1Qx/d3FqWR0FlpOG/cvukAXfB12A49Y4iiA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
+      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
       "peer": true,
       "engines": {
         "node": ">=16"
@@ -7645,9 +7679,9 @@
       }
     },
     "node_modules/udx-native": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.7.2.tgz",
-      "integrity": "sha512-VfLxd6HN9QOU+acpbgzcEcK67pHHJnJUuEGp0W5a5TzsCQdXAVdwA8/cUqbXYKRPIXIlZ3rHMGH/qfxlqUH9SQ==",
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.7.12.tgz",
+      "integrity": "sha512-2/51ij0eYzOQuaoB3IoAO6sVMtHH7Paaw7OKnTws4wfSVGNYoVA2tMrnaeOsIeZ8DZUfLDcLZi5+de0IAIhE6w==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -7684,6 +7718,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -7776,9 +7816,9 @@
       "peer": true
     },
     "node_modules/whatwg-fetch": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==",
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "peer": true
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rpc-reflector": "^1.3.11"
   },
   "peerDependencies": {
-    "@mapeo/core": "^9.0.0-alpha.1"
+    "@mapeo/core": "9.0.0-alpha.4"
   },
   "devDependencies": {
     "@digidem/types": "^2.1.0",

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,19 @@ import {
   SubChannel,
 } from './lib/sub-channel.js'
 
-/** @typedef {import('rpc-reflector/client.js').ClientApi<import('@mapeo/core').MapeoManager>} MapeoClientApi */
+/**
+ * @typedef {import('rpc-reflector/client.js').ClientApi<import('@mapeo/core/dist/mapeo-project.js').MapeoProject>} MapeoProjectClientApi
+ */
+
+/**
+ * @typedef {import('rpc-reflector/client.js').ClientApi<
+ *   Omit<
+ *     import('@mapeo/core').MapeoManager,
+ *     'getProject'
+ *   > & {
+ *     getProject: (projectPublicId: string) => Promise<MapeoProjectClientApi>
+ *   }
+ * >} MapeoClientApi */
 
 const CLOSE = Symbol('close')
 
@@ -57,11 +69,12 @@ export function createMapeoClient(messagePort) {
     },
   })
 
-  return client
+  // TS can't know the type of the proxy, so we cast it in the function return
+  return /** @type {any} */ (client)
 
   /**
    * @param {string} projectPublicId
-   * @returns {Promise<import('rpc-reflector/client.js').ClientApi<import('@mapeo/core/dist/mapeo-project.js').MapeoProject>>}
+   * @returns {Promise<MapeoProjectClientApi>}
    */
   async function createProjectClient(projectPublicId) {
     const existingClientPromise = projectClientPromises.get(projectPublicId)
@@ -93,7 +106,7 @@ export function createMapeoClient(messagePort) {
 }
 
 /**
- * @param {import('rpc-reflector').ClientApi<import('@mapeo/core').MapeoManager>} client client created with `createMapeoClient`
+ * @param {MapeoClientApi} client client created with `createMapeoClient`
  * @returns {Promise<void>}
  */
 export async function closeMapeoClient(client) {

--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,7 @@ import {
 } from './lib/sub-channel.js'
 
 /**
- * @typedef {import('rpc-reflector/client.js').ClientApi<import('@mapeo/core/dist/mapeo-project.js').MapeoProject>} MapeoProjectClientApi
+ * @typedef {import('rpc-reflector/client.js').ClientApi<import('@mapeo/core/dist/mapeo-project.js').MapeoProject>} MapeoProjectApi
  */
 
 /**
@@ -17,7 +17,7 @@ import {
  *     import('@mapeo/core').MapeoManager,
  *     'getProject'
  *   > & {
- *     getProject: (projectPublicId: string) => Promise<MapeoProjectClientApi>
+ *     getProject: (projectPublicId: string) => Promise<MapeoProjectApi>
  *   }
  * >} MapeoClientApi */
 
@@ -74,7 +74,7 @@ export function createMapeoClient(messagePort) {
 
   /**
    * @param {string} projectPublicId
-   * @returns {Promise<MapeoProjectClientApi>}
+   * @returns {Promise<MapeoProjectApi>}
    */
   async function createProjectClient(projectPublicId) {
     const existingClientPromise = projectClientPromises.get(projectPublicId)

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export { createMapeoClient, closeMapeoClient } from './client.js'
 export { createMapeoServer } from './server.js'
 
 /** @typedef {import('./client.js').MapeoClientApi} MapeoClientApi */
+/** @typedef {import('./client.js').MapeoProjectApi} MapeoProjectApi */

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -4,9 +4,24 @@ import { MessageChannel } from 'node:worker_threads'
 import RAM from 'random-access-memory'
 import { KeyManager } from '@mapeo/crypto'
 import { MapeoManager } from '@mapeo/core'
+import { createRequire } from 'node:module'
+import path from 'node:path'
 
 import { createMapeoClient, closeMapeoClient } from '../src/client.js'
 import { createMapeoServer } from '../src/server.js'
+
+const require = createRequire(import.meta.url)
+const MAPEO_CORE_PKG_FOLDER = path.dirname(
+  require.resolve('@mapeo/core/package.json'),
+)
+const projectMigrationsFolder = path.join(
+  MAPEO_CORE_PKG_FOLDER,
+  'drizzle/project',
+)
+const clientMigrationsFolder = path.join(
+  MAPEO_CORE_PKG_FOLDER,
+  'drizzle/client',
+)
 
 test('IPC wrappers work', async () => {
   const { client, cleanup } = setup()
@@ -147,6 +162,8 @@ function setup() {
     rootKey: KeyManager.generateRootKey(),
     dbFolder: ':memory:',
     coreStorage: () => new RAM(),
+    projectMigrationsFolder,
+    clientMigrationsFolder,
   })
 
   // Since v14.7.0, Node's MessagePort extends EventTarget (https://nodejs.org/api/worker_threads.html#class-messageport)


### PR DESCRIPTION
Previously `client.getProject()` was returning `Promise<MapeoProject>`.
It should return `Promise<ClientApi<MapeoProject>>`.

The `ClientApi` wrapper ensures that all properties and methods are
async (a consequence of calling the API over IPC).