### PR TITLE
chore!: update to @mapeo/core@9.0.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "node": ">=18.17.1"
       },
       "peerDependencies": {
-        "@mapeo/core": "9.0.0-alpha.5"
+        "@mapeo/core": "9.0.0-alpha.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -636,12 +636,6 @@
       "integrity": "sha512-1F8m574UObc3HuJoGGdmiOe2Ft9ObVypEKoniREs5v2G03wF/nb3YRTYFjKmI0z4S5NkdJwPFRwo7MjTjkI7Qg==",
       "peer": true
     },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-      "peer": true
-    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -652,9 +646,9 @@
       }
     },
     "node_modules/@mapeo/core": {
-      "version": "9.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.5.tgz",
-      "integrity": "sha512-SqhDAnxYeF4FrGUXLCDsUerq45kHMcf15CIFW6PGfsUTu/Izmia0KtI7iN9xPW5rh/8S6YTpmCK9dFch0dqH9Q==",
+      "version": "9.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.6.tgz",
+      "integrity": "sha512-b1eHOmgVbtE02YAMR/kgfgHX5Mt//4gV290pgC+dPpZqccAgDIdBlaviJKRIGHCM16ZETdilx1NvSH+PJHYYGA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -672,7 +666,6 @@
         "better-sqlite3": "^8.7.0",
         "big-sparse-array": "^1.0.3",
         "bogon": "^1.1.0",
-        "bonjour-service": "^1.2.1",
         "compact-encoding": "^2.12.0",
         "corestore": "^6.8.4",
         "debug": "^4.3.4",
@@ -689,6 +682,7 @@
         "mime": "^4.0.1",
         "multi-core-indexer": "^1.0.0-alpha.9",
         "p-defer": "^4.0.0",
+        "p-event": "^6.0.1",
         "p-timeout": "^6.1.2",
         "patch-package": "^8.0.0",
         "protobufjs": "^7.2.3",
@@ -1712,16 +1706,6 @@
         "compact-encoding-net": "^1.2.0"
       }
     },
-    "node_modules/bonjour-service": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
-      "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "multicast-dns": "^7.2.5"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2685,18 +2669,6 @@
         "streamx": "^2.13.2",
         "time-ordered-set": "^1.0.2",
         "udx-native": "^1.5.3"
-      }
-    },
-    "node_modules/dns-packet": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
-      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-      "peer": true,
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -5549,19 +5521,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/multicast-dns": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
-      "peer": true,
-      "dependencies": {
-        "dns-packet": "^5.2.2",
-        "thunky": "^1.0.2"
-      },
-      "bin": {
-        "multicast-dns": "cli.js"
-      }
-    },
     "node_modules/mutexify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
@@ -6038,6 +5997,21 @@
       "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "peer": true,
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7999,12 +7973,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/thunky": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "peer": true
     },
     "node_modules/time-ordered-set": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rpc-reflector": "^1.3.11"
   },
   "peerDependencies": {
-    "@mapeo/core": "9.0.0-alpha.5"
+    "@mapeo/core": "9.0.0-alpha.6"
   },
   "devDependencies": {
     "@digidem/types": "^2.1.0",


### PR DESCRIPTION
This is a breaking change because @mapeo/core had breaking changes.

Required for <https://github.com/digidem/comapeo-mobile/pull/245>.