### PR TITLE
fix!: use fixed MessagePortLike from rpc-reflector@4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "p-defer": "^4.0.1",
-        "rpc-reflector": "^4.0.0-pre.1"
+        "rpc-reflector": "^4.0.0"
       },
       "devDependencies": {
         "@comapeo/core": "7.0.1",
@@ -6598,9 +6598,9 @@
       "license": "MIT"
     },
     "node_modules/rpc-reflector": {
-      "version": "4.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-4.0.0-pre.1.tgz",
-      "integrity": "sha512-ChhjpXLQ5DMqOKoIxAH40DoOBHpbt2+a8EhE7Xj7ga1lY8s1x8+3CEjXIa6tUBsXMAo1wwl/HSLwqcfunOwbfw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-4.0.0.tgz",
+      "integrity": "sha512-TRc5BCQD9iNZg2eisRzKPiCVKoaaHM8lnZUx2K9tbXfeOuOiD1bvSzAlUJaSU5Mhfn7ZEhCD82LZ1qQ2AhqNqA==",
       "license": "ISC",
       "dependencies": {
         "abstract-logging": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.4",
         "p-defer": "^4.0.1",
-        "rpc-reflector": "^3.0.1"
+        "rpc-reflector": "^4.0.0-pre.1"
       },
       "devDependencies": {
         "@comapeo/core": "7.0.1",
@@ -6599,12 +6598,11 @@
       "license": "MIT"
     },
     "node_modules/rpc-reflector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-3.0.1.tgz",
-      "integrity": "sha512-yUcgwFwrEWMgMgCjLUJwRYGT9KuIYyBb1KI7kqfxC83Y0oXNVwxTKIT3YrkPjuGm72YpU8o3Nj2nI7YFOaI3mQ==",
+      "version": "4.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-4.0.0-pre.1.tgz",
+      "integrity": "sha512-ChhjpXLQ5DMqOKoIxAH40DoOBHpbt2+a8EhE7Xj7ga1lY8s1x8+3CEjXIa6tUBsXMAo1wwl/HSLwqcfunOwbfw==",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^18.19.115",
         "abstract-logging": "^2.0.1",
         "ensure-error": "^4.0.0",
         "eventemitter3": "^5.0.1",
@@ -6614,15 +6612,6 @@
         "p-timeout": "^6.1.4",
         "readable-stream": "^4.7.0",
         "serialize-error": "^12.0.0"
-      }
-    },
-    "node_modules/rpc-reflector/node_modules/@types/node": {
-      "version": "18.19.120",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
-      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/rpc-reflector/node_modules/is-stream": {
@@ -7681,6 +7670,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unix-path-resolve": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/digidem/comapeo-ipc#readme",
   "dependencies": {
     "p-defer": "^4.0.1",
-    "rpc-reflector": "^4.0.0-pre.1"
+    "rpc-reflector": "^4.0.0"
   },
   "peerDependencies": {
     "@comapeo/core": "^7.0.1"

--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
   },
   "homepage": "https://github.com/digidem/comapeo-ipc#readme",
   "dependencies": {
-    "eventemitter3": "^5.0.4",
     "p-defer": "^4.0.1",
-    "rpc-reflector": "^3.0.1"
+    "rpc-reflector": "^4.0.0-pre.1"
   },
   "peerDependencies": {
     "@comapeo/core": "^7.0.1"

--- a/src/client.js
+++ b/src/client.js
@@ -25,7 +25,7 @@ import {
 const CLOSE = Symbol('close')
 
 /**
- * @param {import('./lib/sub-channel.js').MessagePortLike} messagePort
+ * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createClient>[1]} [opts]
  *
  * @returns {MapeoClientApi}
@@ -126,7 +126,7 @@ export async function closeMapeoClient(client) {
  * e.g. the different servers for maps, and in the future for serving blobs and
  * icons (once extracted from core)
  *
- * @param {import('./lib/sub-channel.js').MessagePortLike} messagePort
+ * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createClient>[1]} [opts]
  * @return {AppRpcApi}
  */

--- a/src/lib/sub-channel.js
+++ b/src/lib/sub-channel.js
@@ -9,7 +9,7 @@ export const MANAGER_CHANNEL_ID = '@@manager'
 
 /**
  * @typedef {Object} Events
- * @property {(message: any) => void} message
+ * @property {(message: unknown) => void} message
  */
 
 /** @implements {MessagePortLike} */
@@ -18,7 +18,7 @@ export class SubChannel {
   #messagePort
   /** @type {'idle' | 'active' | 'closed'} */
   #state
-  /** @type {Array<{id: string, message: any}>} */
+  /** @type {Array<{id: string, message: unknown}>} */
   #queued
   #handleMessageEvent
 
@@ -99,7 +99,7 @@ export class SubChannel {
 
     this.#state = 'active'
 
-    /** @type {{id: string, message: any} | undefined} */
+    /** @type {{id: string, message: unknown} | undefined} */
     let data
     while ((data = this.#queued.shift())) {
       this.#handleMessageEvent({ data })

--- a/src/lib/sub-channel.js
+++ b/src/lib/sub-channel.js
@@ -1,23 +1,19 @@
-import { EventEmitter } from 'eventemitter3'
-import { extractMessageEventData } from './utils.js'
+import { isRelevantEventData } from './utils.js'
 
 // Ideally unique ID used for identifying "global" Mapeo IPC messages
 export const MAPEO_RPC_ID = '@@mapeo-rpc'
 export const APP_RPC_ID = '@@app-rpc'
 export const MANAGER_CHANNEL_ID = '@@manager'
 
+/** @import {MessagePortLike, MessageEvent} from 'rpc-reflector' */
+
 /**
  * @typedef {Object} Events
  * @property {(message: any) => void} message
  */
 
-/**
- * Node's built-in types for MessagePort are misleading so we opt for this limited type definition
- * that fits our usage and works in both Node and browser contexts
- * @typedef {Pick<EventTarget, 'addEventListener' | 'removeEventListener'> & { postMessage: (message: any) => void }} MessagePortLike
- */
-
-export class SubChannel extends EventEmitter {
+/** @implements {MessagePortLike} */
+export class SubChannel {
   #id
   #messagePort
   /** @type {'idle' | 'active' | 'closed'} */
@@ -26,37 +22,36 @@ export class SubChannel extends EventEmitter {
   #queued
   #handleMessageEvent
 
+  /** @type {Set<(message: MessageEvent) => void>} */
+  #listeners = new Set()
+
   /**
    * @param {MessagePortLike} messagePort Parent channel to add namespace to
    * @param {string} id ID for the subchannel
    */
   constructor(messagePort, id) {
-    super()
-
     this.#id = id
     this.#messagePort = messagePort
     this.#state = 'idle'
     this.#queued = []
 
     /**
-     * @param {unknown} event
+     * @param {{ data: unknown }} event
      */
-    this.#handleMessageEvent = (event) => {
-      const value = extractMessageEventData(event)
+    this.#handleMessageEvent = ({ data }) => {
+      if (!isRelevantEventData(data)) return
 
-      if (!isRelevantEvent(value)) return
-
-      const { id, message } = value
+      const { id, message } = data
 
       if (this.#id !== id) return
 
       switch (this.#state) {
         case 'idle': {
-          this.#queued.push(value)
+          this.#queued.push(data)
           break
         }
         case 'active': {
-          this.emit('message', message)
+          this.dispatchEvent({ data: message })
           break
         }
         case 'closed': {
@@ -67,6 +62,24 @@ export class SubChannel extends EventEmitter {
     }
 
     this.#messagePort.addEventListener('message', this.#handleMessageEvent)
+  }
+
+  /**
+   * @param {'message'} type
+   * @param {(event: MessageEvent) => void} listener
+   */
+  addEventListener(type, listener) {
+    if (type !== 'message') return
+    this.#listeners.add(listener)
+  }
+
+  /**
+   * @param {'message'} type
+   * @param {(event: MessageEvent) => void} listener
+   */
+  removeEventListener(type, listener) {
+    if (type !== 'message') return
+    this.#listeners.delete(listener)
   }
 
   get id() {
@@ -87,9 +100,9 @@ export class SubChannel extends EventEmitter {
     this.#state = 'active'
 
     /** @type {{id: string, message: any} | undefined} */
-    let event
-    while ((event = this.#queued.shift())) {
-      this.#handleMessageEvent(event)
+    let data
+    while ((data = this.#queued.shift())) {
+      this.#handleMessageEvent({ data })
     }
   }
 
@@ -102,16 +115,11 @@ export class SubChannel extends EventEmitter {
     // Node types are incorrect (as of v14, Node's MessagePort should also extend [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget))
     this.#messagePort.removeEventListener('message', this.#handleMessageEvent)
   }
-}
 
-/**
- * @param {unknown} event
- * @returns {event is { id: string, message: any }}
- */
-function isRelevantEvent(event) {
-  if (!event || typeof event !== 'object') return false
-  if (!('id' in event && 'message' in event)) return false
-  if (typeof event.id !== 'string') return false
-
-  return true
+  /** @param {MessageEvent} event */
+  dispatchEvent(event) {
+    for (const listener of this.#listeners) {
+      listener(event)
+    }
+  }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,15 +1,11 @@
 /**
- * @template T
- * @param {T} event
- * @returns {T extends { data: infer D } ? D : T}
+ * @param {unknown} data
+ * @returns {data is { id: string, message: any }}
  */
-export function extractMessageEventData(event) {
-  // In browser-like contexts, the actual payload will live in the `event.data` field
-  // https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/message_event#event_properties
-  if (event && typeof event === 'object' && 'data' in event) {
-    return /** @type {any} */ (event.data)
-  }
+export function isRelevantEventData(data) {
+  if (!data || typeof data !== 'object') return false
+  if (!('id' in data && 'message' in data)) return false
+  if (typeof data.id !== 'string') return false
 
-  // In Node the event is the actual data that was sent
-  return /** @type {any} */ (event)
+  return true
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,6 +1,6 @@
 /**
  * @param {unknown} data
- * @returns {data is { id: string, message: any }}
+ * @returns {data is { id: string, message: unknown }}
  */
 export function isRelevantEventData(data) {
   if (!data || typeof data !== 'object') return false

--- a/src/server.js
+++ b/src/server.js
@@ -5,11 +5,11 @@ import {
   MAPEO_RPC_ID,
   SubChannel,
 } from './lib/sub-channel.js'
-import { extractMessageEventData } from './lib/utils.js'
+import { isRelevantEventData } from './lib/utils.js'
 
 /**
  * @param {import('@comapeo/core').MapeoManager} manager
- * @param {import('./lib/sub-channel.js').MessagePortLike} messagePort
+ * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createServer>[2]} [opts]
  */
 export function createMapeoServer(manager, messagePort, opts) {
@@ -57,14 +57,11 @@ export function createMapeoServer(manager, messagePort, opts) {
   }
 
   /**
-   * @param {unknown} payload
+   * @param {{ data: unknown }} payload
    */
-  async function handleMessage(payload) {
-    const data = extractMessageEventData(payload)
-
-    if (!data || typeof data !== 'object' || !('message' in data)) return
-
-    const id = 'id' in data && typeof data.id === 'string' ? data.id : null
+  async function handleMessage({ data }) {
+    if (!isRelevantEventData(data)) return
+    const { id } = data
 
     if (!id || id === MANAGER_CHANNEL_ID || id === MAPEO_RPC_ID) return
 
@@ -96,7 +93,7 @@ export function createMapeoServer(manager, messagePort, opts) {
 
     existingProjectServers.set(id, { close })
 
-    projectChannel.emit('message', data.message)
+    projectChannel.dispatchEvent({ data: data.message })
 
     projectChannel.start()
   }
@@ -133,7 +130,7 @@ export class MapeoRpcApi {
  * RPC messages that are not part of core, e.g. the different servers for maps,
  * and in the future for serving blobs and icons (once extracted from core)
  * @param {RpcApi} rpc
- * @param {import('./lib/sub-channel.js').MessagePortLike} messagePort
+ * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createServer>[2]} [opts]
  */
 export function createAppRpcServer(rpc, messagePort, opts) {

--- a/tests/app-rpc.js
+++ b/tests/app-rpc.js
@@ -1,6 +1,5 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { MessageChannel } from 'node:worker_threads'
 
 import { createAppRpcClient, closeAppRpcClient } from '../src/client.js'
 import { createAppRpcServer } from '../src/server.js'

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,3 @@
-import { MessageChannel } from 'node:worker_threads'
 import { KeyManager } from '@mapeo/crypto'
 import { MapeoManager } from '@comapeo/core'
 import { createRequire } from 'node:module'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2023"],
+    "lib": ["es2023", "DOM"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "noEmit": true,


### PR DESCRIPTION
The `MessagePortLike` type in `rpc-reflector`
    always had issues with uncertain behaviour around
    EventEmitter vs EventTarget behaviour and event
    detection via a fragile `event.data` check. The
    new version of `rpc-reflector` fixes this, and
    this commit updates SubChannel to implement the
    more precise `MessagePortLike` contract, which is
    now `postMessage` plus `addEventListener` /
    `removeEventListener` for `'message'` events.

**BREAKING CHANGE:** This is a breaking change, because `createMapeoClient()` and `createAppRpcServer()` are now stricter about what they will accept.