### PR TITLE
chore: enable pre-release major & minor and add correct tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ on:
           - minor
           - major
           - prerelease
-          # - prepatch
-          # - preminor
-          # - premajor
+          - prepatch
+          - preminor
+          - premajor
   pull_request:
     types: [closed]
     branches: [main]
@@ -37,10 +37,10 @@ jobs:
           sync-semver-tags: false
           access: 'public'
           # This prefix is added before the prerelease number, e.g. `v3.0.0-next.0`
-          # prerelease-prefix: 'alpha'
+          prerelease-prefix: 'pre'
           semver: ${{ github.event.inputs.semver }}
-          # Prereleases are published under the `alpha` npm dist-tag
-          # npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'alpha' || 'latest' }}
+          # Prereleases are published under the `pre` npm dist-tag
+          npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'pre' || 'latest' }}
           # Don't notify linked issues
           notify-linked-issues: false
           publish-mode: oidc


### PR DESCRIPTION
I wanted to create a pre-release for #61, which requires the `premajor` semver bump. Also I wanted the version name to be `9.0.0-pre.0` not `9.0.0-0` and the npm tag to be `pre`.