### PR TITLE
fix(ci): release prereleases on non-main merges and clean up draft on close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,21 @@ on:
           - premajor
   pull_request:
     types: [closed]
-    branches: [main]
 
 jobs:
   release:
-    if: ${{github.event_name != 'pull_request' || github.event.pull_request.merged}}
+    # Run for the manual trigger, or when a release PR opened by the optic bot
+    # is closed. The action publishes on merge and deletes its draft release on
+    # close-without-merge. The bot-author + title checks make this a no-op for
+    # any other PR. Merges into non-main branches only release prereleases
+    # (branch like `release/vX.Y.Z-pre.N`); main releases anything.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.login == 'optic-release-automation[bot]'
+        && startsWith(github.event.pull_request.title, '[OPTIC-RELEASE-AUTOMATION]')
+        && (!github.event.pull_request.merged
+          || github.event.pull_request.base.ref == 'main'
+          || contains(github.event.pull_request.head.ref, '-pre.')))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

Adjusts the `release` workflow (which drives `nearform-actions/optic-release-automation-action`) to handle three cases it previously didn't.

1. **Cleanup on close-without-merge.** The job no longer requires `pull_request.merged`. When a release PR is closed without merging, the action deletes the draft GitHub release it created — that path now actually runs.
2. **Prereleases on non-main merges.** Removed the `branches: [main]` trigger filter so merges into non-main branches reach the job. The job is gated to only release prereleases there (branch like `release/vX.Y.Z-pre.N`); merges into `main` release anything. This is why [#65](https://github.com/digidem/comapeo-ipc/pull/65) merged but never published.
3. **Robust release-PR detection.** The job `if` checks the optic bot author (`optic-release-automation[bot]`) and the `[OPTIC-RELEASE-AUTOMATION]` title prefix — the action's own `app-name` default and `PR_TITLE_PREFIX`. Any other closed PR skips the job entirely (zero steps, no runner).

## Notes

- The trigger now fires on every PR close in the repo, but the job is *skipped* for non-release PRs. There is no `on:`-level filter for PR author/head branch, so job-level `if` is the correct place for this.
- `pull_request` events run the workflow file from the **base** branch. Once this lands on `main`, branches cut from main inherit the fix; pre-existing long-lived branches need it merged in before a non-main prerelease merge will trigger.