### PR TITLE
feat!: make app RPC generic over the api shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Returns a client instance that reflects the interface of the `manager` provided 
 
 Closes the IPC client instance. Does not close or destroy the `messagePort` provided to [`createMapeoClient`](#createmapeoclientmessageport-messageportlike-clientapimapeomanager).
 
+### `createAppRpcServer<T>(appRpcApi: T, messagePort: MessagePortLike): { close: () => void }`
+
+Creates an RPC server for application-specific needs that are not part of core, e.g. a map server (and in future blob and icon servers). Unlike the Mapeo server, the shape is generic: `appRpcApi` is any object of (possibly nested) async methods, and the consuming app decides that shape.
+
+Returns an object with a `close()` method. Does not close or destroy the `messagePort`.
+
+### `createAppRpcClient<T>(messagePort: MessagePortLike, opts?: { timeout?: number }): AppRpcClientApi<T>`
+
+Creates the matching client. `T` is the shape of the `appRpcApi` passed to `createAppRpcServer`. Because the shape can't be inferred from the `messagePort`, annotate the result with `AppRpcClientApi<T>` to type the client; without it `T` defaults to `unknown` and member access is a type error.
+
+### `closeAppRpcClient(appRpcClient: AppRpcClientApi): void`
+
+Closes the app RPC client. Does not close or destroy the `messagePort`.
+
 ## Usage
 
 In the server:
@@ -78,6 +92,30 @@ client.on('invite-received', (invite) => {
 
 // Close the client
 closeMapeoClient(client)
+```
+
+For app-specific RPC, the app defines the API shape on both sides:
+
+```ts
+import { createAppRpcServer, createAppRpcClient } from '@comapeo/ipc'
+
+type MapServerApi = {
+  mapServer: {
+    listen(options?: { localPort?: number }): Promise<{ localPort: number }>
+    close(): Promise<void>
+  }
+}
+
+// In the server, pass an implementation of that shape:
+const appRpcServer = createAppRpcServer<MapServerApi>(
+  { mapServer: { async listen(options) { ... }, async close() {} } },
+  messagePort,
+)
+
+// In the client, pass the same shape to type the client:
+const appRpcClient = createAppRpcClient<MapServerApi>(messagePort)
+
+const { localPort } = await appRpcClient.mapServer.listen({ localPort: 3000 })
 ```
 
 ## License

--- a/src/client.js
+++ b/src/client.js
@@ -13,6 +13,24 @@ import {
  */
 
 /**
+ * Phantom brand so an app RPC client can't be confused with a raw rpc-reflector
+ * client (e.g. when passed to `closeAppRpcClient`).
+ *
+ * @template Tag
+ * @typedef {{ readonly [K in `__appRpc_${Tag & string}`]: void }} Brand
+ */
+
+/**
+ * Client-side type for an app RPC api. `T` is the api shape defined by the
+ * consuming app (the same object passed to `createAppRpcServer`): each method
+ * becomes async and nested namespaces are preserved. Defaults to `unknown` so
+ * that an un-annotated client is a type error rather than silently untyped.
+ *
+ * @template [T=unknown]
+ * @typedef {import('rpc-reflector/client.js').ClientApi<T & {}> & Brand<'AppRpcApi'>} AppRpcClientApi
+ */
+
+/**
  * @typedef {import('rpc-reflector/client.js').ClientApi<
  *   Omit<
  *     import('@comapeo/core').MapeoManager,
@@ -118,31 +136,27 @@ export async function closeMapeoClient(client) {
 }
 
 /**
- * @typedef {import('rpc-reflector/client.js').ClientApi<import('./server.js').RpcApi>} AppRpcApi
- */
-
-/**
  * Create an rpc client for application RPC messages that are not part of core,
  * e.g. the different servers for maps, and in the future for serving blobs and
  * icons (once extracted from core)
  *
+ * @template [T=unknown]
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createClient>[1]} [opts]
- * @return {AppRpcApi}
+ * @return {AppRpcClientApi<T>}
  */
 export function createAppRpcClient(messagePort, opts = {}) {
   const appRpcChannel = new SubChannel(messagePort, APP_RPC_ID)
-  const appRpcClient = /** @type {AppRpcApi} */ (
-    createClient(appRpcChannel, opts)
-  )
+  const appRpcClient = createClient(appRpcChannel, opts)
   appRpcChannel.start()
-  return appRpcClient
+  // TS can't know the type of the client, so we cast it in the function return
+  return /** @type {AppRpcClientApi<T>} */ (appRpcClient)
 }
 
 /**
  * Close the app RPC client (removes listeners but does not close the message port)
  *
- * @param {AppRpcApi} appRpcClient client created with `createAppRpcClient`
+ * @param {AppRpcClientApi} appRpcClient client created with `createAppRpcClient`
  */
 export function closeAppRpcClient(appRpcClient) {
   createClient.close(appRpcClient)

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,7 @@ export { createMapeoServer, createAppRpcServer } from './server.js'
 
 /** @typedef {import('./client.js').MapeoClientApi} MapeoClientApi */
 /** @typedef {import('./client.js').MapeoProjectApi} MapeoProjectApi */
-/** @typedef {import('./client.js').AppRpcApi} AppRpcApi */
+/**
+ * @template [T=unknown]
+ * @typedef {import('./client.js').AppRpcClientApi<T>} AppRpcClientApi
+ */

--- a/src/server.js
+++ b/src/server.js
@@ -120,22 +120,17 @@ export class MapeoRpcApi {
 }
 
 /**
- * @typedef {object} RpcApi
- * @property {object} mapServer
- * @property {(options?: { localPort?: number, remotePort?: number }) => Promise<{ localPort: number, remotePort: number }>} mapServer.listen
- * @property {() => Promise<void>} mapServer.close
- */
-
-/**
- * RPC messages that are not part of core, e.g. the different servers for maps,
- * and in the future for serving blobs and icons (once extracted from core)
- * @param {RpcApi} rpc
+ * Generic RPC channel for app-specific needs, such as managing the map server.
+ * The RPC shape is defined by the app.
+ *
+ * @template {Record<string, any>} T
+ * @param {T} appRpcApi
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createServer>[2]} [opts]
  */
-export function createAppRpcServer(rpc, messagePort, opts) {
+export function createAppRpcServer(appRpcApi, messagePort, opts) {
   const appRpcChannel = new SubChannel(messagePort, APP_RPC_ID)
-  const appRpcServer = createServer(rpc, appRpcChannel, opts)
+  const appRpcServer = createServer(appRpcApi, appRpcChannel, opts)
   appRpcChannel.start()
   return {
     close() {

--- a/tests/app-rpc.js
+++ b/tests/app-rpc.js
@@ -5,15 +5,21 @@ import { createAppRpcClient, closeAppRpcClient } from '../src/client.js'
 import { createAppRpcServer } from '../src/server.js'
 
 /**
+ * Wire up a server and client over a fresh channel for an app-defined api. The
+ * app RPC channel is generic: the consuming app decides the shape of the api,
+ * so the tests below exercise both flat and nested shapes.
+ *
+ * @template {Record<string, any>} T
  * @param {import('node:test').TestContext} t
- * @param {import('../src/server.js').RpcApi} [rpcApi]
+ * @param {T} api
  */
-function setup(t, rpcApi) {
+function setup(t, api) {
   const { port1, port2 } = new MessageChannel()
 
-  const api = rpcApi || createMockRpcApi()
   const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
+  const client = /** @type {import('../src/client.js').AppRpcClientApi<T>} */ (
+    createAppRpcClient(port2)
+  )
 
   port1.start()
   port2.start()
@@ -28,189 +34,130 @@ function setup(t, rpcApi) {
   return { server, client, api }
 }
 
-/** @returns {import('../src/server.js').RpcApi} */
-function createMockRpcApi() {
+function createFlatApi() {
   return {
-    mapServer: {
-      async listen(options) {
-        const localPort = options?.localPort || 3000
-        return { localPort, remotePort: 3001 }
-      },
-      async close() {},
+    async ping() {
+      return 'pong'
+    },
+    /**
+     * @param {number} a
+     * @param {number} b
+     */
+    async add(a, b) {
+      return a + b
     },
   }
 }
 
-test('AppRpc client can call server method and get result', async (t) => {
-  const { client } = setup(t)
+function createNestedApi() {
+  return {
+    mapServer: {
+      /** @param {{ localPort?: number }} [options] */
+      async listen(options) {
+        return { localPort: options?.localPort || 3000, remotePort: 3001 }
+      },
+      async close() {},
+    },
+    blobServer: {
+      /** @param {string} blobId */
+      async getUrl(blobId) {
+        return `http://localhost:3002/${blobId}`
+      },
+    },
+  }
+}
 
-  const result = await client.mapServer.listen({ localPort: 4000 })
+test('AppRpc relays calls to a flat app-defined api', async (t) => {
+  const { client } = setup(t, createFlatApi())
 
-  assert.equal(result.localPort, 4000)
+  assert.equal(await client.ping(), 'pong')
+  assert.equal(await client.add(2, 3), 5)
 })
 
-test('AppRpc client can call multiple methods', async (t) => {
-  const { client } = setup(t)
+test('AppRpc relays calls to a nested app-defined api', async (t) => {
+  const { client } = setup(t, createNestedApi())
 
-  const listenResult = await client.mapServer.listen({ localPort: 5000 })
-  assert.equal(listenResult.localPort, 5000)
+  const listenResult = await client.mapServer.listen({ localPort: 4000 })
+  assert.equal(listenResult.localPort, 4000)
+  assert.equal(listenResult.remotePort, 3001)
+
+  assert.equal(
+    await client.blobServer.getUrl('abc'),
+    'http://localhost:3002/abc',
+  )
 
   await client.mapServer.close()
 })
 
-test('AppRpc concurrent calls resolve correctly', async (t) => {
+test('AppRpc resolves concurrent calls independently', async (t) => {
   let callCount = 0
 
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen(options) {
-        callCount++
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
-      },
-      async close() {},
+  const { client } = setup(t, {
+    /** @param {number} n */
+    async double(n) {
+      callCount++
+      return n * 2
     },
-  }
-
-  const { client } = setup(t, api)
+  })
 
   const results = await Promise.all([
-    client.mapServer.listen({ localPort: 4001 }),
-    client.mapServer.listen({ localPort: 4002 }),
-    client.mapServer.listen({ localPort: 4003 }),
+    client.double(1),
+    client.double(2),
+    client.double(3),
   ])
 
   assert.equal(callCount, 3)
-  assert.equal(results[0].localPort, 4001)
-  assert.equal(results[1].localPort, 4002)
-  assert.equal(results[2].localPort, 4003)
+  assert.deepEqual(results, [2, 4, 6])
 })
 
-test('AppRpc server method errors are propagated to client', async (t) => {
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen() {
-        throw new Error('Address already in use')
-      },
-      async close() {},
+test('AppRpc propagates server method errors to the client', async (t) => {
+  const { client } = setup(t, {
+    async fail() {
+      throw new Error('boom')
     },
-  }
-
-  const { client } = setup(t, api)
-
-  await assert.rejects(() => client.mapServer.listen({}), {
-    message: 'Address already in use',
   })
+
+  await assert.rejects(() => client.fail(), { message: 'boom' })
 })
 
-test('AppRpc client calls fail after server closes', async (t) => {
-  const { port1, port2 } = new MessageChannel()
+test('AppRpc client calls fail after the server closes', async (t) => {
+  const api = createFlatApi()
+  const { client, server } = setup(t, api)
 
-  const api = createMockRpcApi()
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
-
-  port1.start()
-  port2.start()
-
-  // Verify it works first
-  const result = await client.mapServer.listen({ localPort: 6000 })
-  assert.equal(result.localPort, 6000)
+  // Works before closing.
+  assert.equal(await client.ping(), 'pong')
 
   server.close()
   closeAppRpcClient(client)
 
-  await assert.rejects(() => client.mapServer.listen({ localPort: 6001 }))
-
-  t.after(() => {
-    port1.close()
-    port2.close()
-  })
+  await assert.rejects(() => client.ping())
 })
 
-test('AppRpc works with nested object API', async (t) => {
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen(options) {
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
-      },
-      async close() {},
-    },
-  }
+test('AppRpc server close is idempotent', (t) => {
+  const { server } = setup(t, createFlatApi())
 
-  const { client } = setup(t, api)
-
-  const result = await client.mapServer.listen({ localPort: 7000 })
-  assert.equal(result.localPort, 7000)
-})
-
-test('AppRpc server close is idempotent', async (t) => {
-  const { port1, port2 } = new MessageChannel()
-
-  const api = createMockRpcApi()
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
-
-  port1.start()
-  port2.start()
-
-  // Closing server multiple times should not throw
+  // Closing more than once must not throw; t.after closes again too.
   server.close()
   server.close()
-
-  closeAppRpcClient(client)
-
-  t.after(() => {
-    port1.close()
-    port2.close()
-  })
 })
 
-test('AppRpc multiple independent clients on separate channels', async (t) => {
-  const { port1: serverPort1, port2: clientPort1 } = new MessageChannel()
-  const { port1: serverPort2, port2: clientPort2 } = new MessageChannel()
-
-  let callCount = 0
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen(options) {
-        callCount++
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
-      },
-      async close() {},
+test('AppRpc isolates independent clients on separate channels', async (t) => {
+  const { client: client1 } = setup(t, {
+    async whoami() {
+      return 'one'
     },
-  }
-
-  const server1 = createAppRpcServer(api, serverPort1)
-  const server2 = createAppRpcServer(api, serverPort2)
-  const client1 = createAppRpcClient(clientPort1)
-  const client2 = createAppRpcClient(clientPort2)
-
-  serverPort1.start()
-  clientPort1.start()
-  serverPort2.start()
-  clientPort2.start()
+  })
+  const { client: client2 } = setup(t, {
+    async whoami() {
+      return 'two'
+    },
+  })
 
   const [result1, result2] = await Promise.all([
-    client1.mapServer.listen({ localPort: 8001 }),
-    client2.mapServer.listen({ localPort: 8002 }),
+    client1.whoami(),
+    client2.whoami(),
   ])
 
-  assert.equal(result1.localPort, 8001)
-  assert.equal(result2.localPort, 8002)
-  assert.equal(callCount, 2)
-
-  t.after(() => {
-    server1.close()
-    server2.close()
-    closeAppRpcClient(client1)
-    closeAppRpcClient(client2)
-    serverPort1.close()
-    clientPort1.close()
-    serverPort2.close()
-    clientPort2.close()
-  })
+  assert.equal(result1, 'one')
+  assert.equal(result2, 'two')
 })


### PR DESCRIPTION
Makes the app RPC channel generic so the consuming app defines the API shape, instead of the previously hardcoded mapServer type.

- createAppRpcServer and createAppRpcClient are now generic over the api shape
- add exported AppRpcClientApi<T> type; T defaults to unknown so an un-annotated client is a type error rather than silently untyped
- remove the fixed RpcApi and AppRpcApi types
- brand the client type locally rather than adding a type-fest dependency
- rewrite the app-rpc tests for the generic shape and document the app RPC API in the README

Breaking: the RpcApi and AppRpcApi exported types are removed, and the createAppRpc functions now require the app to supply the api shape.