### PR TITLE
feat!: change appRpc to mapServer.getBaseUrl()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "p-defer": "^4.0.1",
-        "rpc-reflector": "^4.0.0"
+        "rpc-reflector": "^4.1.0"
       },
       "devDependencies": {
         "@comapeo/core": "7.0.1",
@@ -2854,10 +2854,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/custom-error-creator": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/custom-error-creator/-/custom-error-creator-1.1.1.tgz",
-      "integrity": "sha512-V1g1pUyk7qF2w4gHm2TwOUYA2vMmhrJJ1U+hwH/VJ4yXj4rHFY3s7yM3rh2xdyB/qcE76pIkdkB1X3KFeqVuvA==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/custom-error-creator/-/custom-error-creator-1.4.0.tgz",
+      "integrity": "sha512-FlGeV6jWzU44ygX8GIzBx2aXc7fcPsyiOi3NA0Votnk7otRUgzc1oLpEB1VewWf1Ih43k7UqU62OTP3xYZ3ycQ==",
       "license": "MIT"
     },
     "node_modules/debounceify": {
@@ -6598,12 +6597,13 @@
       "license": "MIT"
     },
     "node_modules/rpc-reflector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-4.0.0.tgz",
-      "integrity": "sha512-TRc5BCQD9iNZg2eisRzKPiCVKoaaHM8lnZUx2K9tbXfeOuOiD1bvSzAlUJaSU5Mhfn7ZEhCD82LZ1qQ2AhqNqA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-4.1.0.tgz",
+      "integrity": "sha512-BMcnteWv89pAUoEBBeSo272yEiTkVM3mVk5sVGxNgXAu6esUgaUepAP6A2jpxV0yUlrkgyoB8f58ciyahbMxFA==",
       "license": "ISC",
       "dependencies": {
         "abstract-logging": "^2.0.1",
+        "custom-error-creator": "^1.4.0",
         "ensure-error": "^4.0.0",
         "eventemitter3": "^5.0.1",
         "is-plain-obj": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/digidem/comapeo-ipc#readme",
   "dependencies": {
     "p-defer": "^4.0.1",
-    "rpc-reflector": "^4.0.0"
+    "rpc-reflector": "^4.1.0"
   },
   "peerDependencies": {
     "@comapeo/core": "^7.0.1"

--- a/src/server.js
+++ b/src/server.js
@@ -122,8 +122,7 @@ export class MapeoRpcApi {
 /**
  * @typedef {object} RpcApi
  * @property {object} mapServer
- * @property {(options?: { localPort?: number, remotePort?: number }) => Promise<{ localPort: number, remotePort: number }>} mapServer.listen
- * @property {() => Promise<void>} mapServer.close
+ * @property {() => Promise<string>} mapServer.getBaseUrl Return the base URL of the map server
  */
 
 /**

--- a/tests/app-rpc.js
+++ b/tests/app-rpc.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import { createAppRpcClient, closeAppRpcClient } from '../src/client.js'
 import { createAppRpcServer } from '../src/server.js'
+import { ChannelClosedError as RpcChannelClosedError } from 'rpc-reflector/errors.js'
 
 /**
  * @param {import('node:test').TestContext} t
@@ -28,15 +29,15 @@ function setup(t, rpcApi) {
   return { server, client, api }
 }
 
+const MOCK_BASE_URL = 'http://localhost:3000'
+
 /** @returns {import('../src/server.js').RpcApi} */
 function createMockRpcApi() {
   return {
     mapServer: {
-      async listen(options) {
-        const localPort = options?.localPort || 3000
-        return { localPort, remotePort: 3001 }
+      async getBaseUrl() {
+        return MOCK_BASE_URL
       },
-      async close() {},
     },
   }
 }
@@ -44,18 +45,9 @@ function createMockRpcApi() {
 test('AppRpc client can call server method and get result', async (t) => {
   const { client } = setup(t)
 
-  const result = await client.mapServer.listen({ localPort: 4000 })
+  const result = await client.mapServer.getBaseUrl()
 
-  assert.equal(result.localPort, 4000)
-})
-
-test('AppRpc client can call multiple methods', async (t) => {
-  const { client } = setup(t)
-
-  const listenResult = await client.mapServer.listen({ localPort: 5000 })
-  assert.equal(listenResult.localPort, 5000)
-
-  await client.mapServer.close()
+  assert.equal(result, MOCK_BASE_URL)
 })
 
 test('AppRpc concurrent calls resolve correctly', async (t) => {
@@ -64,48 +56,49 @@ test('AppRpc concurrent calls resolve correctly', async (t) => {
   /** @type {import('../src/server.js').RpcApi} */
   const api = {
     mapServer: {
-      async listen(options) {
+      async getBaseUrl() {
         callCount++
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
+        return MOCK_BASE_URL + `-${callCount}`
       },
-      async close() {},
     },
   }
 
   const { client } = setup(t, api)
 
   const results = await Promise.all([
-    client.mapServer.listen({ localPort: 4001 }),
-    client.mapServer.listen({ localPort: 4002 }),
-    client.mapServer.listen({ localPort: 4003 }),
+    client.mapServer.getBaseUrl(),
+    client.mapServer.getBaseUrl(),
+    client.mapServer.getBaseUrl(),
   ])
 
   assert.equal(callCount, 3)
-  assert.equal(results[0].localPort, 4001)
-  assert.equal(results[1].localPort, 4002)
-  assert.equal(results[2].localPort, 4003)
+  assert.equal(results[0], MOCK_BASE_URL + '-1')
+  assert.equal(results[1], MOCK_BASE_URL + '-2')
+  assert.equal(results[2], MOCK_BASE_URL + '-3')
 })
 
 test('AppRpc server method errors are propagated to client', async (t) => {
+  const expectedError = new Error('Error')
   /** @type {import('../src/server.js').RpcApi} */
   const api = {
     mapServer: {
-      async listen() {
-        throw new Error('Address already in use')
+      async getBaseUrl() {
+        throw expectedError
       },
-      async close() {},
     },
   }
 
   const { client } = setup(t, api)
 
-  await assert.rejects(() => client.mapServer.listen({}), {
-    message: 'Address already in use',
-  })
+  await assert.rejects(() => client.mapServer.getBaseUrl(), expectedError)
 })
 
 test('AppRpc client calls fail after server closes', async (t) => {
   const { port1, port2 } = new MessageChannel()
+  t.after(() => {
+    port1.close()
+    port2.close()
+  })
 
   const api = createMockRpcApi()
   const server = createAppRpcServer(api, port1)
@@ -115,35 +108,15 @@ test('AppRpc client calls fail after server closes', async (t) => {
   port2.start()
 
   // Verify it works first
-  const result = await client.mapServer.listen({ localPort: 6000 })
-  assert.equal(result.localPort, 6000)
+  const result = await client.mapServer.getBaseUrl()
+  assert.equal(result, MOCK_BASE_URL)
 
   server.close()
   closeAppRpcClient(client)
 
-  await assert.rejects(() => client.mapServer.listen({ localPort: 6001 }))
-
-  t.after(() => {
-    port1.close()
-    port2.close()
+  await assert.rejects(() => client.mapServer.getBaseUrl(), {
+    code: RpcChannelClosedError.code,
   })
-})
-
-test('AppRpc works with nested object API', async (t) => {
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen(options) {
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
-      },
-      async close() {},
-    },
-  }
-
-  const { client } = setup(t, api)
-
-  const result = await client.mapServer.listen({ localPort: 7000 })
-  assert.equal(result.localPort, 7000)
 })
 
 test('AppRpc server close is idempotent', async (t) => {
@@ -165,52 +138,5 @@ test('AppRpc server close is idempotent', async (t) => {
   t.after(() => {
     port1.close()
     port2.close()
-  })
-})
-
-test('AppRpc multiple independent clients on separate channels', async (t) => {
-  const { port1: serverPort1, port2: clientPort1 } = new MessageChannel()
-  const { port1: serverPort2, port2: clientPort2 } = new MessageChannel()
-
-  let callCount = 0
-  /** @type {import('../src/server.js').RpcApi} */
-  const api = {
-    mapServer: {
-      async listen(options) {
-        callCount++
-        return { localPort: options?.localPort || 3000, remotePort: 3001 }
-      },
-      async close() {},
-    },
-  }
-
-  const server1 = createAppRpcServer(api, serverPort1)
-  const server2 = createAppRpcServer(api, serverPort2)
-  const client1 = createAppRpcClient(clientPort1)
-  const client2 = createAppRpcClient(clientPort2)
-
-  serverPort1.start()
-  clientPort1.start()
-  serverPort2.start()
-  clientPort2.start()
-
-  const [result1, result2] = await Promise.all([
-    client1.mapServer.listen({ localPort: 8001 }),
-    client2.mapServer.listen({ localPort: 8002 }),
-  ])
-
-  assert.equal(result1.localPort, 8001)
-  assert.equal(result2.localPort, 8002)
-  assert.equal(callCount, 2)
-
-  t.after(() => {
-    server1.close()
-    server2.close()
-    closeAppRpcClient(client1)
-    closeAppRpcClient(client2)
-    serverPort1.close()
-    clientPort1.close()
-    serverPort2.close()
-    clientPort2.close()
   })
 })


### PR DESCRIPTION
Having the frontend be responsible for listening and closing the map server is the wrong decision: it means the map server cannot start until the frontend starts, and it's hard for the frontend to know when it has been already called. A better API is to return the baseUrl, which is what mobile does already by wrapping this API in the frontend.