### PR TITLE
fix!: reject getProject() after the client is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Error classes are available from the `@comapeo/ipc/errors.js` entrypoint:
 ```ts
 import {
   ProjectClosedError,
-  ManagerClosedError,
+  ClientClosedError,
   RpcChannelClosedError,
   RpcTimeoutError,
 } from '@comapeo/ipc/errors.js'
@@ -52,7 +52,7 @@ import {
 After a reference is closed, calls made on it reject with a descriptive error:
 
 - **`ProjectClosedError`** (`code: 'PROJECT_CLOSED'`) — a method (including nested namespaces such as `project.observation.*`) was called on a project reference after that project was closed, either via `await project.close()` or by the server closing the project. A re-opened reference from a fresh `client.getProject(id)` is unaffected.
-- **`ClientClosedError`** (`code: 'CLIENT_CLOSED'`) — a method was called on the CoMapeo client, or on any project reference, after the whole client was torn down with [`closeMapeoClient`](#closemapeoclientmapeoclient-clientapimapeomanager-void).
+- **`ClientClosedError`** (`code: 'CLIENT_CLOSED'`) — a method was called on the CoMapeo client, or on any project reference, after the whole client was torn down with [`closeMapeoClient`](#closemapeoclientmapeoclient-clientapimapeomanager-void). This includes `getProject(id)`, which after close rejects with `ClientClosedError` rather than returning a reference — whether or not that project was fetched earlier.
 
 RPC methods return a rejected `Promise` carrying the error, so failures surface through normal `await`/`.catch()` handling. The exception is the event-emitter methods (`on`, `once`, `off`, `removeListener`, `emit`, etc.), which return synchronously rather than a promise — after close these **throw** the same error synchronously instead, so it surfaces at the call site rather than as an unhandled rejection.
 

--- a/src/client.js
+++ b/src/client.js
@@ -164,11 +164,13 @@ export function createMapeoClient(messagePort, opts = {}) {
    * @returns {Promise<MapeoProjectApi>}
    */
   async function createProjectClient(projectPublicId) {
+    // Checked before the cache lookup so `getProject` rejects uniformly after
+    // close — whether or not this id was fetched (and cached) earlier.
+    if (clientClosed) throw new ClientClosedError()
+
     const existingClientPromise = projectClientPromises.get(projectPublicId)
 
     if (existingClientPromise) return existingClientPromise
-
-    if (clientClosed) throw new ClientClosedError()
 
     /** @type {import('p-defer').DeferredPromise<import('rpc-reflector/client.js').ClientApi<import('@comapeo/core').MapeoProject>>} */
     const deferred = pDefer()

--- a/src/server.js
+++ b/src/server.js
@@ -54,6 +54,15 @@ export function createMapeoServer(manager, messagePort, opts) {
    */
   const closedInstanceIds = new Set()
 
+  /**
+   * Instance ids we've already warned about dropping. Reaching the drop branch
+   * is a "shouldn't happen" case (see `handleMessage`); we warn once per id so
+   * a chatty foreign sender on a shared port can't flood logs while a genuine
+   * routing bug stays visible.
+   * @type {Set<string>}
+   */
+  const droppedInstanceIds = new Set()
+
   let instanceCounter = 0
 
   const mapeoRpcApi = new MapeoRpcApi({
@@ -132,6 +141,7 @@ export function createMapeoServer(manager, messagePort, opts) {
 
       currentInstanceForProject.clear()
       closedInstanceIds.clear()
+      droppedInstanceIds.clear()
       managerServer.close()
       managerChannel.close()
       mapeoRpcServer.close()
@@ -146,7 +156,14 @@ export function createMapeoServer(manager, messagePort, opts) {
     if (!isRelevantEventData(data)) return
     const { id } = data
 
-    if (!id || id === MANAGER_CHANNEL_ID || id === MAPEO_RPC_ID) return
+    if (
+      !id ||
+      id === MANAGER_CHANNEL_ID ||
+      id === MAPEO_RPC_ID ||
+      id === APP_RPC_ID
+    ) {
+      return
+    }
 
     if (existingInstanceChannels.has(id)) return
 
@@ -173,10 +190,18 @@ export function createMapeoServer(manager, messagePort, opts) {
       return
     }
 
-    // Unknown instance id — silently drop. Could happen for a malformed
-    // message or a stale message from a prior `comapeo-ipc` session sharing
-    // the same messagePort.
-    console.error(`Dropping message for unknown instance id ${id}`)
+    // Unknown instance id. With the manager/mapeo-rpc/app-rpc channels and
+    // every open and closed project instance accounted for above, reaching
+    // here means the message isn't ours: a stale message from a prior
+    // `comapeo-ipc` session sharing this port, or a malformed/foreign message.
+    // We never minted this id, so the sender isn't a paired client and we
+    // can't answer it — drop it, warning once per id (see `droppedInstanceIds`).
+    if (!droppedInstanceIds.has(id)) {
+      droppedInstanceIds.add(id)
+      console.warn(
+        `comapeo-ipc: dropping message for unrecognised channel id "${id}"`,
+      )
+    }
   }
 }
 

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -169,15 +169,17 @@ test('Client calls fail after server closes', async (t) => {
   server.close()
   await closeMapeoClient(client)
 
-  const projectAfter = await client.getProject(projectId)
+  // After close, getProject rejects uniformly with ClientClosedError — both
+  // for a project fetched earlier (cached) and for one never fetched.
+  await assert.rejects(() => client.getProject(projectId), {
+    code: ClientClosedError.code,
+  })
+  await assert.rejects(() => client.getProject('never-fetched'), {
+    code: ClientClosedError.code,
+  })
 
-  // Even after server closes we're still able to get the project ipc instance, which is okay
-  // because any field access should fail on that, rendering it unusable
-  // Adding this assertion to track changes in this behavior
-  assert.ok(projectAfter)
-
-  // Doing it this way to speed up the test because each should wait for a timeout
-  // Attempting to access any fields on the ipc instances should fail (aside from client.getProject, which is tested above)
+  // Method calls on the client and on a previously-obtained project reference
+  // also reject with ClientClosedError.
   const results = await Promise.allSettled([
     client.listProjects(),
     projectBefore.$getProjectSettings(),
@@ -194,7 +196,7 @@ test('Client calls fail after server closes', async (t) => {
       // @ts-ignore
       result.reason.code,
       ClientClosedError.code,
-      'after the client is closed, calls reject with ManagerClosedError',
+      'after the client is closed, calls reject with ClientClosedError',
     )
   }
 })


### PR DESCRIPTION
getProject(id) now rejects with ClientClosedError after closeMapeoClient, instead of returning an unusable wrapper for ids fetched before close. Behaviour is uniform whether or not the id was fetched earlier. Also corrects the ClientClosedError name in the README.

Stacked on #73.