### PR TITLE
test: add a thin integration test against real @comapeo/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,10 @@
       "devDependencies": {
         "@comapeo/core": "7.0.1",
         "@eslint/js": "9.39.4",
+        "@mapeo/crypto": "^1.1.0",
         "@types/node": "24.12.0",
         "eslint": "9.39.4",
+        "fastify": "4.29.1",
         "globals": "17.4.0",
         "husky": "9.1.7",
         "lint-staged": "15.5.2",
@@ -145,6 +147,26 @@
         "xstate": "^5.19.2",
         "yauzl-promise": "^4.0.0",
         "zip-stream-promise": "^1.0.2"
+      }
+    },
+    "node_modules/@comapeo/core/node_modules/@mapeo/crypto": {
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@mapeo/crypto/-/crypto-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-TEK8HN1W0XZOOADIMxa4saXtqAZKyBDeVVn3RBCcPaCiOGHeYy43/0rMnBVTbXZCLsLVPnOXwv6vg+vUkasrWQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/b4a": "^1.6.0",
+        "b4a": "^1.6.4",
+        "base-x": "^3.0.9",
+        "base32.js": "^0.1.0",
+        "compact-encoding": "^2.5.1",
+        "compact-encoding-net": "^1.0.1",
+        "compact-encoding-struct": "^1.2.0",
+        "crc": "^3.8.0",
+        "lodash": "^4.17.21",
+        "sodium-universal": "^4.0.0",
+        "z32": "^1.0.0"
       }
     },
     "node_modules/@comapeo/core/node_modules/dot-prop": {
@@ -1117,21 +1139,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapeo/crypto": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@mapeo/crypto/-/crypto-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-TEK8HN1W0XZOOADIMxa4saXtqAZKyBDeVVn3RBCcPaCiOGHeYy43/0rMnBVTbXZCLsLVPnOXwv6vg+vUkasrWQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapeo/crypto/-/crypto-1.1.0.tgz",
+      "integrity": "sha512-8vkqvbskpAFlWkVUa/sC/CcpTVkbr5+gjTG3e2FigbGBb4q+2SzMjA+pZpQY/ahhDz7W9qfG7J/Dwwyg8cQ7aw==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "@types/b4a": "^1.6.0",
-        "b4a": "^1.6.4",
         "base-x": "^3.0.9",
         "base32.js": "^0.1.0",
-        "compact-encoding": "^2.5.1",
+        "compact-encoding": "^2.19.2",
         "compact-encoding-net": "^1.0.1",
         "compact-encoding-struct": "^1.2.0",
         "crc": "^3.8.0",
-        "lodash": "^4.17.21",
         "sodium-universal": "^4.0.0",
         "z32": "^1.0.0"
       }
@@ -1635,10 +1654,11 @@
       }
     },
     "node_modules/@types/b4a": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/b4a/-/b4a-1.6.1.tgz",
-      "integrity": "sha512-pvn/TM2ux+sCtHm2jChFFCldoockrGOuoNgrAE3eP1LVcaKIg1d+qXMy4xBxTRWB0QxsrPRUexcgRW0lZEy/QQ==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@types/b4a/-/b4a-1.6.5.tgz",
+      "integrity": "sha512-jVCTfZJVaU6AqYC19wHEvK+MUNkh32iv8Hhb8hvJFk8bX3Um/Lq7litbOkcKKAH8gU31mgWvpNu8ijWQN7JWZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2604,9 +2624,9 @@
       }
     },
     "node_modules/compact-encoding": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.15.0.tgz",
-      "integrity": "sha512-af/NomxL9Mo0lqCk++rxLLDZI+lJqeBrPt4dK6FbjxTCEhfC9yQAIoO6yq9ixyCirce0luQwErkwJrhem6clxA==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.19.2.tgz",
+      "integrity": "sha512-/YjhHQE/5L4F7l5Bht69dRbP9RV6zoJPeowi8bMKQxNKe3Nh6hOY8pBGoVE9fz5GaWfEd8fWJ2aU9sB4KZuMYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,10 @@
   "devDependencies": {
     "@comapeo/core": "7.0.1",
     "@eslint/js": "9.39.4",
+    "@mapeo/crypto": "^1.1.0",
     "@types/node": "24.12.0",
     "eslint": "9.39.4",
+    "fastify": "4.29.1",
     "globals": "17.4.0",
     "husky": "9.1.7",
     "lint-staged": "15.5.2",

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import os from 'node:os'
+import fs from 'node:fs'
+import { KeyManager } from '@mapeo/crypto'
+import { MapeoManager } from '@comapeo/core'
+import Fastify from 'fastify'
+
+import { createMapeoClient, closeMapeoClient } from '../src/client.js'
+import { createMapeoServer } from '../src/server.js'
+
+const require = createRequire(import.meta.url)
+
+const COMAPEO_CORE_PKG_FOLDER = path.dirname(
+  path.dirname(require.resolve('@comapeo/core')),
+)
+const projectMigrationsFolder = path.join(
+  COMAPEO_CORE_PKG_FOLDER,
+  'drizzle/project',
+)
+const clientMigrationsFolder = path.join(
+  COMAPEO_CORE_PKG_FOLDER,
+  'drizzle/client',
+)
+
+// One end-to-end test against the real `@comapeo/core` MapeoManager. The rest
+// of the suite runs against an in-memory fake (see fake-manager.js); this one
+// proves the IPC wiring matches the real manager/project API shape and that
+// real values round-trip over the channel.
+test('end-to-end against a real MapeoManager', async (t) => {
+  const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'comapeo-ipc-it-db-'))
+  const coreDir = fs.mkdtempSync(path.join(os.tmpdir(), 'comapeo-ipc-it-core-'))
+
+  const manager = new MapeoManager({
+    rootKey: KeyManager.generateRootKey(),
+    dbFolder: dbDir,
+    coreStorage: coreDir,
+    projectMigrationsFolder,
+    clientMigrationsFolder,
+    fastify: Fastify(),
+  })
+
+  const { port1, port2 } = new MessageChannel()
+  const server = createMapeoServer(manager, port1)
+  const client = createMapeoClient(port2)
+
+  port1.start()
+  port2.start()
+
+  t.after(async () => {
+    server.close()
+    await closeMapeoClient(client)
+    fs.rmSync(dbDir, { recursive: true, force: true })
+    fs.rmSync(coreDir, { recursive: true, force: true })
+    port1.close()
+    port2.close()
+  })
+
+  // Manager methods round-trip.
+  const projectId = await client.createProject({ name: 'mapeo' })
+  assert.ok(projectId)
+
+  const listed = await client.listProjects()
+  assert.equal(listed.length, 1)
+
+  // Per-project subchannel: settings, a nested-namespace write + read back,
+  // then close.
+  const project = await client.getProject(projectId)
+
+  const settings = await project.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+
+  const obs = await project.observation.create({
+    schemaName: 'observation',
+    attachments: [],
+    tags: {},
+  })
+  const readBack = await project.observation.getByDocId(obs.docId)
+  assert.equal(readBack.docId, obs.docId)
+
+  await project.close()
+})


### PR DESCRIPTION
The suite runs against an in-memory fake manager; this adds one end-to-end test against the real MapeoManager to prove the IPC wiring matches the real manager/project API shape and that real values round-trip over the channel: create/list project, project settings, a nested-namespace observation write + read back, and close.

Restores the fastify and @mapeo/crypto devDeps it needs (removed in #75).