### PR TITLE
refactor!: rename exports to CoMapeo core/services naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> **No longer maintained.** Release notes now live in [GitHub Releases](https://github.com/digidem/comapeo-ipc/releases). This file is kept for historical entries only.
+
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ### [2.0.2](https://github.com/digidem/comapeo-ipc/compare/v2.0.1...v2.0.2) (2024-10-22)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ IPC wrappers for [CoMapeo Core](https://github.com/digidem/comapeo-core). Meant 
 
 - [Installation](#installation)
 - [API](#api)
+- [Behaviour](#behaviour)
 - [Errors](#errors)
 - [Usage](#usage)
 - [License](#license)
@@ -20,21 +21,76 @@ npm install @comapeo/ipc @comapeo/core
 
 ## API
 
-### `createMapeoServer(manager: MapeoManager, messagePort: MessagePortLike): { close: () => void }`
+### `createComapeoCoreServer(manager: MapeoManager, messagePort: MessagePortLike): { close: () => void }`
 
 Creates the IPC server instance. `manager` is a `@comapeo/core` `MapeoManager` instance and `messagePort` is an interface that resembles a [`MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort).
 
 Returns an object with a `close()` method, which removes relevant event listeners from the `messagePort`. Does not close or destroy the `messagePort`.
 
-### `createMapeoClient(messagePort: MessagePortLike, opts?: { timeout?: number }): ClientApi<MapeoManager>`
+### `createComapeoCoreClient(messagePort: MessagePortLike, opts?: { timeout?: number }): ClientApi<MapeoManager>`
 
 Creates the IPC client instance. `messagePort` is an interface that resembles a [`MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort). `opts.timeout` is an optional timeout used for sending and receiving messages over the channel.
 
-Returns a client instance that reflects the interface of the `manager` provided to [`createMapeoServer`](#createmapeoservermanager-mapeomanager-messageport-messageportlike--close---void). Refer to the [`rpc-reflector` docs](https://github.com/digidem/rpc-reflector#const-clientapi--createclientchannel) for additional information about how to use this.
+Returns a client instance that reflects the interface of the `manager` provided to [`createComapeoCoreServer`](#createcomapeocoreservermanager-mapeomanager-messageport-messageportlike--close---void). Refer to the [`rpc-reflector` docs](https://github.com/digidem/rpc-reflector#const-clientapi--createclientchannel) for additional information about how to use this.
 
-### `closeMapeoClient(mapeoClient: ClientApi<MapeoManager>): void`
+### `closeComapeoCoreClient(client: ClientApi<MapeoManager>): Promise<void>`
 
-Closes the IPC client instance. Does not close or destroy the `messagePort` provided to [`createMapeoClient`](#createmapeoclientmessageport-messageportlike-clientapimapeomanager).
+Closes the IPC client instance. Does not close or destroy the `messagePort` provided to [`createComapeoCoreClient`](#createcomapeocoreclientmessageport-messageportlike-opts--timeout-number--clientapimapeomanager).
+
+Some application services live outside `@comapeo/core` (for example the map server URL). They have their own client/server pair, which can share the same `messagePort` as the core client/server (see [Behaviour](#behaviour)).
+
+### `createComapeoServicesServer(services: ComapeoServicesApi, messagePort: MessagePortLike): { close: () => void }`
+
+Creates the services server. `services` implements the services API (currently `{ mapServer: { getBaseUrl(): Promise<string> } }`; the blob and icon servers will join it once extracted from core). Returns an object with a `close()` method; like `createComapeoCoreServer` it does not close the `messagePort`.
+
+### `createComapeoServicesClient(messagePort: MessagePortLike, opts?: { timeout?: number }): ClientApi<ComapeoServicesApi>`
+
+Creates the services client, reflecting the `services` object passed to [`createComapeoServicesServer`](#createcomapeoservicesserverservices-comapeoservicesapi-messageport-messageportlike--close---void).
+
+### `closeComapeoServicesClient(servicesClient: ClientApi<ComapeoServicesApi>): void`
+
+Closes the services client. Does not close or destroy the `messagePort`.
+
+## Behaviour
+
+These are the guarantees the wrappers add on top of [`rpc-reflector`](https://github.com/digidem/rpc-reflector); they are exercised by the test suite.
+
+### One port, many channels
+
+A single `messagePort` multiplexes several independent RPC channels: the core (manager) API, an internal project-routing channel used to open projects, one channel per open project, and the services API. Every id this library mints carries a shared `@@comapeo/` prefix and messages are namespaced per channel, so:
+
+- `createComapeoCoreServer` and `createComapeoServicesServer` can run over the same `messagePort` (paired with `createComapeoCoreClient` and `createComapeoServicesClient` on the other end) without interfering with each other.
+- Closing one server or client does not disturb the others sharing the port.
+- Traffic from a foreign sender sharing the port (any id without the `@@comapeo/` prefix) is ignored.
+
+The wrappers never close or destroy the `messagePort` itself — that is the caller's responsibility.
+
+### Calls and concurrency
+
+- Every method call returns a `Promise` that resolves with the return value, or rejects with the error thrown on the server. Errors are reconstructed across the channel, preserving their `code`.
+- Any number of calls may be in flight at once; each is matched to its response independently.
+- Arguments and return values must be serializable by your transport (for example, the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) for a `MessageChannel` or worker thread).
+- A call rejects with [`RpcTimeoutError`](#errors) if no response arrives within `opts.timeout`.
+
+### Projects
+
+`client.getProject(id)` resolves with a client that reflects the `MapeoProject` API, including nested namespaces such as `project.observation.*`.
+
+- **Deduplicated.** Concurrent or repeated `getProject(id)` calls for an open project resolve to the same reference and open the project only once on the server.
+- **Missing projects.** If the project does not exist, `getProject(id)` rejects with `NotFoundError` (from `@comapeo/core`). A failed lookup is not cached, so a later call for an id that does exist still succeeds.
+- **Isolation.** Closing one project does not affect other open projects.
+
+### Lifecycle
+
+- `project.close()` closes the project on the server and tears down its channel. It is idempotent — repeated calls resolve like the first.
+- After a project is closed — via `project.close()` **or** by the server closing it — every method on that reference rejects with [`ProjectClosedError`](#errors).
+- A project can be re-opened: after closing, `getProject(id)` opens a fresh instance and returns a new reference. Calls on the old, closed reference never reach the re-opened project — they keep rejecting.
+- `closeComapeoCoreClient(client)` tears down the manager, the project-routing channel, and every open project reference. After this, all calls — including `getProject(id)` — reject with [`ClientClosedError`](#errors). (The services client is independent; close it separately with [`closeComapeoServicesClient`](#closecomapeoservicesclientservicesclient-clientapicomapeoservicesapi-void).)
+- Calls already in flight when a close happens reject with [`RpcChannelClosedError`](#errors); they are not re-routed.
+
+### Events
+
+The client reflects the `EventEmitter` interface of the manager and of each project. `client.on(event, listener)` forwards events emitted on the server across the channel; `removeListener` / `off` stop the forwarding. After a reference is closed these emitter methods behave differently — see [Errors](#errors).
 
 ## Errors
 
@@ -52,11 +108,11 @@ import {
 After a reference is closed, calls made on it reject with a descriptive error:
 
 - **`ProjectClosedError`** (`code: 'PROJECT_CLOSED'`) — a method (including nested namespaces such as `project.observation.*`) was called on a project reference after that project was closed, either via `await project.close()` or by the server closing the project. A re-opened reference from a fresh `client.getProject(id)` is unaffected.
-- **`ClientClosedError`** (`code: 'CLIENT_CLOSED'`) — a method was called on the CoMapeo client, or on any project reference, after the whole client was torn down with [`closeMapeoClient`](#closemapeoclientmapeoclient-clientapimapeomanager-void). This includes `getProject(id)`, which after close rejects with `ClientClosedError` rather than returning a reference — whether or not that project was fetched earlier.
+- **`ClientClosedError`** (`code: 'CLIENT_CLOSED'`) — a method was called on the CoMapeo client, or on any project reference, after the whole client was torn down with [`closeComapeoCoreClient`](#closecomapeocoreclientclient-clientapimapeomanager-promisevoid). This includes `getProject(id)`, which after close rejects with `ClientClosedError` rather than returning a reference — whether or not that project was fetched earlier.
 
 RPC methods return a rejected `Promise` carrying the error, so failures surface through normal `await`/`.catch()` handling. The exception is the event-emitter methods (`on`, `once`, `off`, `removeListener`, `emit`, etc.), which return synchronously rather than a promise — after close these **throw** the same error synchronously instead, so it surfaces at the call site rather than as an unhandled rejection.
 
-Calls that were already in flight when the close happened are not re-routed: they reject with **`RpcChannelClosedError`** as the underlying channel tears down. `RpcTimeoutError` is thrown when a call exceeds the `opts.timeout` passed to [`createMapeoClient`](#createmapeoclientmessageport-messageportlike-clientapimapeomanager).
+Calls that were already in flight when the close happened are not re-routed: they reject with **`RpcChannelClosedError`** as the underlying channel tears down. `RpcTimeoutError` is thrown when a call exceeds the `opts.timeout` passed to [`createComapeoCoreClient`](#createcomapeocoreclientmessageport-messageportlike-opts--timeout-number--clientapimapeomanager).
 
 ## Usage
 
@@ -64,14 +120,14 @@ In the server:
 
 ```ts
 import { MapeoManager } from '@comapeo/core'
-import { createMapeoServer } from '@comapeo/ipc'
+import { createComapeoCoreServer } from '@comapeo/ipc'
 
-// Create Mapeo manager instance
+// Create CoMapeo Core manager instance
 const manager = new MapeoManager({...})
 
 // Create the server instance
 // `messagePort` can vary based on context (e.g. a port from a MessageChannel, a NodeJS Mobile bridge channel, etc.)
-const server = createMapeoServer(manager, messagePort)
+const server = createComapeoCoreServer(manager, messagePort)
 
 // Maybe at some point later on...
 
@@ -82,25 +138,25 @@ server.close()
 In the client:
 
 ```ts
-import { createMapeoClient, closeMapeoClient } from '@comapeo/ipc'
+import { createComapeoCoreClient, closeComapeoCoreClient } from '@comapeo/ipc'
 
 // Create the client instance
 // `messagePort` can vary based on context (e.g. a port from a MessageChannel, a NodeJS Mobile bridge channel, etc.)
-const client = createMapeoClient(messagePort)
+const client = createComapeoCoreClient(messagePort)
 
 // Use the MapeoManager instance from the server via the client!
 const projectId = await client.createProject({...})
 const project = await client.getProject(projectId)
 const projects = await client.listProjects()
 
-client.on('invite-received', (invite) => {
+client.on('local-peers', (peers) => {
   // ...
 })
 
 // Maybe at some point later on...
 
 // Close the client
-closeMapeoClient(client)
+closeComapeoCoreClient(client)
 ```
 
 ## License

--- a/src/client.js
+++ b/src/client.js
@@ -2,9 +2,9 @@ import { createClient } from 'rpc-reflector/client.js'
 import pDefer from 'p-defer'
 
 import {
-  APP_RPC_ID,
   MANAGER_CHANNEL_ID,
-  MAPEO_RPC_ID,
+  PROJECT_ROUTING_ID,
+  SERVICES_ID,
   SubChannel,
 } from './lib/sub-channel.js'
 import { ClientClosedError, ProjectClosedError } from './errors.js'
@@ -58,7 +58,7 @@ function createClosedProxy(makeError) {
 }
 
 /**
- * @typedef {import('rpc-reflector/client.js').ClientApi<import('@comapeo/core').MapeoProject>} MapeoProjectApi
+ * @typedef {import('rpc-reflector/client.js').ClientApi<import('@comapeo/core').MapeoProject>} ComapeoProjectClientApi
  */
 
 /**
@@ -67,9 +67,9 @@ function createClosedProxy(makeError) {
  *     import('@comapeo/core').MapeoManager,
  *     'getProject'
  *   > & {
- *     getProject: (projectPublicId: string) => Promise<MapeoProjectApi>
+ *     getProject: (projectPublicId: string) => Promise<ComapeoProjectClientApi>
  *   }
- * >} MapeoClientApi */
+ * >} ComapeoCoreClientApi */
 
 const CLOSE = Symbol('close')
 
@@ -77,16 +77,16 @@ const CLOSE = Symbol('close')
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createClient>[1]} [opts]
  *
- * @returns {MapeoClientApi}
+ * @returns {ComapeoCoreClientApi}
  */
-export function createMapeoClient(messagePort, opts = {}) {
+export function createComapeoCoreClient(messagePort, opts = {}) {
   /** @type {Map<string, Promise<import('rpc-reflector/client.js').ClientApi<import('@comapeo/core').MapeoProject>>>} */
   const projectClientPromises = new Map()
 
   /**
    * The rpc-reflector client + SubChannel pair for every currently-open
    * project. Entries are removed when the project's wrapped `close()`
-   * settles; `closeMapeoClient` sweeps whatever is left.
+   * settles; `closeComapeoCoreClient` sweeps whatever is left.
    * @type {Set<{
    *   client: import('rpc-reflector/client.js').ClientApi<import('@comapeo/core').MapeoProject>,
    *   channel: SubChannel,
@@ -95,17 +95,17 @@ export function createMapeoClient(messagePort, opts = {}) {
   const openProjectClients = new Set()
 
   const managerChannel = new SubChannel(messagePort, MANAGER_CHANNEL_ID)
-  const mapeoRpcChannel = new SubChannel(messagePort, MAPEO_RPC_ID)
+  const projectRoutingChannel = new SubChannel(messagePort, PROJECT_ROUTING_ID)
 
   /** @type {import('rpc-reflector').ClientApi<import('@comapeo/core').MapeoManager>} */
   const managerClient = createClient(managerChannel, opts)
-  /** @type {import('rpc-reflector').ClientApi<import('./server.js').MapeoRpcApi>} */
-  const mapeoRpcClient = createClient(mapeoRpcChannel, opts)
+  /** @type {import('rpc-reflector').ClientApi<import('./server.js').ProjectRoutingApi>} */
+  const projectRoutingClient = createClient(projectRoutingChannel, opts)
 
-  mapeoRpcChannel.start()
+  projectRoutingChannel.start()
   managerChannel.start()
 
-  // Set once `closeMapeoClient` has torn the whole client down. Read by the
+  // Set once `closeComapeoCoreClient` has torn the whole client down. Read by the
   // manager proxy and the per-project wrappers so that calls after close
   // surface `ManagerClosedError` instead of rpc-reflector's `ChannelClosed`.
   let clientClosed = false
@@ -135,8 +135,8 @@ export function createMapeoClient(messagePort, opts = {}) {
 
           // Closed last so in-flight `assertProjectExists` calls awaited
           // above can complete rather than reject.
-          mapeoRpcChannel.close()
-          createClient.close(mapeoRpcClient)
+          projectRoutingChannel.close()
+          createClient.close(projectRoutingClient)
 
           clientClosed = true
         }
@@ -161,7 +161,7 @@ export function createMapeoClient(messagePort, opts = {}) {
 
   /**
    * @param {string} projectPublicId
-   * @returns {Promise<MapeoProjectApi>}
+   * @returns {Promise<ComapeoProjectClientApi>}
    */
   async function createProjectClient(projectPublicId) {
     // Checked before the cache lookup so `getProject` rejects uniformly after
@@ -186,7 +186,8 @@ export function createMapeoClient(messagePort, opts = {}) {
     /** @type {string} */
     let instanceId
     try {
-      instanceId = await mapeoRpcClient.assertProjectExists(projectPublicId)
+      instanceId =
+        await projectRoutingClient.assertProjectExists(projectPublicId)
     } catch (err) {
       // Failed to open the project — drop the cached promise so a
       // subsequent getProject() call can retry instead of getting back
@@ -257,41 +258,42 @@ export function createMapeoClient(messagePort, opts = {}) {
 }
 
 /**
- * @param {MapeoClientApi} client client created with `createMapeoClient`
+ * @param {ComapeoCoreClientApi} client client created with `createComapeoCoreClient`
  * @returns {Promise<void>}
  */
-export async function closeMapeoClient(client) {
+export async function closeComapeoCoreClient(client) {
   // @ts-expect-error
   return client[CLOSE]()
 }
 
 /**
- * @typedef {import('rpc-reflector/client.js').ClientApi<import('./server.js').RpcApi>} AppRpcApi
+ * @typedef {import('rpc-reflector/client.js').ClientApi<import('./server.js').ComapeoServicesApi>} ComapeoServicesClientApi
  */
 
 /**
- * Create an rpc client for application RPC messages that are not part of core,
- * e.g. the different servers for maps, and in the future for serving blobs and
- * icons (once extracted from core)
+ * Create a client for the app-provided services that live outside
+ * `@comapeo/core` — the map server today, and the blob and icon servers in the
+ * future (once extracted from core). The host app implements the server side;
+ * see {@link import('./server.js').ComapeoServicesApi}.
  *
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createClient>[1]} [opts]
- * @return {AppRpcApi}
+ * @return {ComapeoServicesClientApi}
  */
-export function createAppRpcClient(messagePort, opts = {}) {
-  const appRpcChannel = new SubChannel(messagePort, APP_RPC_ID)
-  const appRpcClient = /** @type {AppRpcApi} */ (
-    createClient(appRpcChannel, opts)
+export function createComapeoServicesClient(messagePort, opts = {}) {
+  const servicesChannel = new SubChannel(messagePort, SERVICES_ID)
+  const servicesClient = /** @type {ComapeoServicesClientApi} */ (
+    createClient(servicesChannel, opts)
   )
-  appRpcChannel.start()
-  return appRpcClient
+  servicesChannel.start()
+  return servicesClient
 }
 
 /**
- * Close the app RPC client (removes listeners but does not close the message port)
+ * Close the services client (removes listeners but does not close the message port)
  *
- * @param {AppRpcApi} appRpcClient client created with `createAppRpcClient`
+ * @param {ComapeoServicesClientApi} servicesClient client created with `createComapeoServicesClient`
  */
-export function closeAppRpcClient(appRpcClient) {
-  createClient.close(appRpcClient)
+export function closeComapeoServicesClient(servicesClient) {
+  createClient.close(servicesClient)
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -17,8 +17,8 @@ export const ProjectClosedError = createErrorClass({
 })
 
 /**
- * Thrown client-side when a method is called after the MapeoManager client
- * (the whole IPC client) has been closed via `closeMapeoClient`.
+ * Thrown client-side when a method is called after the CoMapeo core client
+ * (the whole IPC client) has been closed via `closeComapeoCoreClient`.
  */
 export const ClientClosedError = createErrorClass({
   code: 'CLIENT_CLOSED',

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 export {
-  createMapeoClient,
-  closeMapeoClient,
-  createAppRpcClient,
-  closeAppRpcClient,
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+  createComapeoServicesClient,
+  closeComapeoServicesClient,
 } from './client.js'
-export { createMapeoServer, createAppRpcServer } from './server.js'
+export {
+  createComapeoCoreServer,
+  createComapeoServicesServer,
+} from './server.js'
 
-/** @typedef {import('./client.js').MapeoClientApi} MapeoClientApi */
-/** @typedef {import('./client.js').MapeoProjectApi} MapeoProjectApi */
-/** @typedef {import('./client.js').AppRpcApi} AppRpcApi */
+/** @typedef {import('./client.js').ComapeoCoreClientApi} ComapeoCoreClientApi */
+/** @typedef {import('./client.js').ComapeoProjectClientApi} ComapeoProjectClientApi */
+/** @typedef {import('./client.js').ComapeoServicesClientApi} ComapeoServicesClientApi */
+/** @typedef {import('./server.js').ComapeoServicesApi} ComapeoServicesApi */

--- a/src/lib/sub-channel.js
+++ b/src/lib/sub-channel.js
@@ -1,9 +1,17 @@
 import { isRelevantEventData } from './utils.js'
 
-// Ideally unique ID used for identifying "global" Mapeo IPC messages
-export const MAPEO_RPC_ID = '@@mapeo-rpc'
-export const APP_RPC_ID = '@@app-rpc'
-export const MANAGER_CHANNEL_ID = '@@manager'
+// Shared prefix on every channel id this library mints. It lets the server
+// tell its own traffic from a foreign sender sharing the same port: an id
+// without this prefix isn't ours and is ignored without warning.
+export const COMAPEO_PREFIX = '@@comapeo/'
+
+export const MANAGER_CHANNEL_ID = '@@comapeo/manager'
+export const PROJECT_ROUTING_ID = '@@comapeo/project-routing'
+export const SERVICES_ID = '@@comapeo/services'
+
+// Prefix for per-project instance channel ids; the rest of the id is the
+// project's public id plus a per-open counter (see `openProjectInstance`).
+export const PROJECT_INSTANCE_PREFIX = '@@comapeo/project/'
 
 /** @import {MessagePortLike, MessageEvent} from 'rpc-reflector' */
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,10 @@
 import { createServer } from 'rpc-reflector/server.js'
 import {
-  APP_RPC_ID,
+  COMAPEO_PREFIX,
   MANAGER_CHANNEL_ID,
-  MAPEO_RPC_ID,
+  PROJECT_INSTANCE_PREFIX,
+  PROJECT_ROUTING_ID,
+  SERVICES_ID,
   SubChannel,
 } from './lib/sub-channel.js'
 import { isRelevantEventData } from './lib/utils.js'
@@ -13,7 +15,7 @@ import { ProjectClosedError } from './errors.js'
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createServer>[2]} [opts]
  */
-export function createMapeoServer(manager, messagePort, opts) {
+export function createComapeoCoreServer(manager, messagePort, opts) {
   // Per-project subchannels are keyed by an *instance id* — a string that is
   // unique to one open lifetime of one project. Every time a project is
   // opened (or re-opened after close), a new instance id is minted and
@@ -55,9 +57,10 @@ export function createMapeoServer(manager, messagePort, opts) {
   const closedInstanceIds = new Set()
 
   /**
-   * Instance ids we've already warned about dropping. Reaching the drop branch
-   * is a "shouldn't happen" case (see `handleMessage`); we warn once per id so
-   * a chatty foreign sender on a shared port can't flood logs while a genuine
+   * Instance ids we've already logged an error for. Reaching the drop branch
+   * is a "shouldn't happen" case — a prefixed id we minted but lost track of
+   * (foreign traffic is dropped earlier, see `handleMessage`); we log once
+   * per id so a repeated stray message can't flood logs while a genuine
    * routing bug stays visible.
    * @type {Set<string>}
    */
@@ -65,7 +68,7 @@ export function createMapeoServer(manager, messagePort, opts) {
 
   let instanceCounter = 0
 
-  const mapeoRpcApi = new MapeoRpcApi({
+  const projectRoutingApi = new ProjectRoutingApi({
     getProjectInstance(projectId) {
       const existing = currentInstanceForProject.get(projectId)
       if (existing) return existing
@@ -93,7 +96,7 @@ export function createMapeoServer(manager, messagePort, opts) {
     // to the client through rpc-reflector's standard error response.
     const project = await manager.getProject(projectId)
 
-    const instanceId = `${projectId}:${++instanceCounter}`
+    const instanceId = `${PROJECT_INSTANCE_PREFIX}${projectId}:${++instanceCounter}`
     const projectChannel = new SubChannel(messagePort, instanceId)
     existingInstanceChannels.set(instanceId, projectChannel)
 
@@ -115,13 +118,17 @@ export function createMapeoServer(manager, messagePort, opts) {
   }
 
   const managerChannel = new SubChannel(messagePort, MANAGER_CHANNEL_ID)
-  const mapeoRpcChannel = new SubChannel(messagePort, MAPEO_RPC_ID)
+  const projectRoutingChannel = new SubChannel(messagePort, PROJECT_ROUTING_ID)
 
   const managerServer = createServer(manager, managerChannel, opts)
-  const mapeoRpcServer = createServer(mapeoRpcApi, mapeoRpcChannel, opts)
+  const projectRoutingServer = createServer(
+    projectRoutingApi,
+    projectRoutingChannel,
+    opts,
+  )
 
   managerChannel.start()
-  mapeoRpcChannel.start()
+  projectRoutingChannel.start()
 
   messagePort.addEventListener('message', handleMessage)
 
@@ -144,8 +151,8 @@ export function createMapeoServer(manager, messagePort, opts) {
       droppedInstanceIds.clear()
       managerServer.close()
       managerChannel.close()
-      mapeoRpcServer.close()
-      mapeoRpcChannel.close()
+      projectRoutingServer.close()
+      projectRoutingChannel.close()
     },
   }
 
@@ -156,11 +163,17 @@ export function createMapeoServer(manager, messagePort, opts) {
     if (!isRelevantEventData(data)) return
     const { id } = data
 
+    // Not one of ours. Every id this library mints carries `COMAPEO_PREFIX`,
+    // so an id without it belongs to a foreign sender sharing this port —
+    // drop it silently (no warning) so unrelated traffic can't flood logs.
+    if (!id.startsWith(COMAPEO_PREFIX)) return
+
+    // Reserved channels and currently-open project instances are routed by
+    // their own SubChannel listeners; nothing to do here.
     if (
-      !id ||
       id === MANAGER_CHANNEL_ID ||
-      id === MAPEO_RPC_ID ||
-      id === APP_RPC_ID
+      id === PROJECT_ROUTING_ID ||
+      id === SERVICES_ID
     ) {
       return
     }
@@ -190,15 +203,15 @@ export function createMapeoServer(manager, messagePort, opts) {
       return
     }
 
-    // Unknown instance id. With the manager/mapeo-rpc/app-rpc channels and
-    // every open and closed project instance accounted for above, reaching
-    // here means the message isn't ours: a stale message from a prior
-    // `comapeo-ipc` session sharing this port, or a malformed/foreign message.
-    // We never minted this id, so the sender isn't a paired client and we
-    // can't answer it — drop it, warning once per id (see `droppedInstanceIds`).
+    // Carries our prefix but matches no known channel. With the
+    // manager/project-routing/services channels and every open and closed
+    // project instance accounted for above, reaching here means we minted
+    // this id and lost track of it (or a paired client desynced) — a genuine
+    // routing bug, not foreign traffic. Logged once per id (see
+    // `droppedInstanceIds`).
     if (!droppedInstanceIds.has(id)) {
       droppedInstanceIds.add(id)
-      console.warn(
+      console.error(
         `comapeo-ipc: dropping message for unrecognised channel id "${id}"`,
       )
     }
@@ -230,7 +243,7 @@ function createClosedProjectStub() {
   return new Proxy({}, handler)
 }
 
-export class MapeoRpcApi {
+export class ProjectRoutingApi {
   #getProjectInstance
 
   /**
@@ -256,26 +269,32 @@ export class MapeoRpcApi {
 }
 
 /**
- * @typedef {object} RpcApi
+ * The contract for app-provided services that live outside `@comapeo/core` —
+ * the map server today, and the blob and icon servers in the future (once
+ * extracted from core). The host app implements this; `@comapeo/core-react`
+ * and other consumers reach it through `createComapeoServicesClient`.
+ *
+ * @typedef {object} ComapeoServicesApi
  * @property {object} mapServer
  * @property {() => Promise<string>} mapServer.getBaseUrl Return the base URL of the map server
  */
 
 /**
- * RPC messages that are not part of core, e.g. the different servers for maps,
- * and in the future for serving blobs and icons (once extracted from core)
- * @param {RpcApi} rpc
+ * Serve the app-provided services API (see {@link ComapeoServicesApi}) over
+ * the shared message port.
+ *
+ * @param {ComapeoServicesApi} services
  * @param {import('rpc-reflector').MessagePortLike} messagePort
  * @param {Parameters<typeof createServer>[2]} [opts]
  */
-export function createAppRpcServer(rpc, messagePort, opts) {
-  const appRpcChannel = new SubChannel(messagePort, APP_RPC_ID)
-  const appRpcServer = createServer(rpc, appRpcChannel, opts)
-  appRpcChannel.start()
+export function createComapeoServicesServer(services, messagePort, opts) {
+  const servicesChannel = new SubChannel(messagePort, SERVICES_ID)
+  const servicesServer = createServer(services, servicesChannel, opts)
+  servicesChannel.start()
   return {
     close() {
-      appRpcServer.close()
-      appRpcChannel.close()
+      servicesServer.close()
+      servicesChannel.close()
     },
   }
 }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { NotFoundError } from '@comapeo/core/errors.js'
 
 import { ClientClosedError, RpcChannelClosedError } from '../src/errors.js'
-import { closeMapeoClient } from '../src/client.js'
+import { closeComapeoCoreClient } from '../src/client.js'
 
 import { setup } from './helpers.js'
 import { FakeManager } from './fake-manager.js'
@@ -141,7 +141,7 @@ test('Client calls fail after server closes', async (t) => {
   await projectBefore.$getProjectSettings()
 
   server.close()
-  await closeMapeoClient(client)
+  await closeComapeoCoreClient(client)
 
   // After close, getProject rejects uniformly with ClientClosedError — both
   // for a project fetched earlier (cached) and for one never fetched.
@@ -184,7 +184,7 @@ test('In-flight calls reject with RpcChannelClosedError when the client closes',
   // it rejects with the underlying channel-closed error as the channel tears
   // down. This is the behaviour the README documents for in-flight calls.
   const inFlight = client.listProjects()
-  const closing = closeMapeoClient(client)
+  const closing = closeComapeoCoreClient(client)
 
   await assert.rejects(inFlight, { code: RpcChannelClosedError.code })
   await closing

--- a/tests/events.js
+++ b/tests/events.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import pDefer from 'p-defer'
 
 import { ClientClosedError, ProjectClosedError } from '../src/errors.js'
-import { closeMapeoClient } from '../src/client.js'
+import { closeComapeoCoreClient } from '../src/client.js'
 
 import { setup } from './helpers.js'
 import { FakeManager } from './fake-manager.js'
@@ -72,7 +72,7 @@ test('EventEmitter methods throw synchronously after the project is closed', asy
 test('EventEmitter methods throw synchronously after the client is closed', async (t) => {
   const { client } = setup(t)
 
-  await closeMapeoClient(client)
+  await closeComapeoCoreClient(client)
 
   assert.throws(() => client.on('local-peers', () => {}), {
     code: ClientClosedError.code,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,8 @@
-import { createMapeoClient, closeMapeoClient } from '../src/client.js'
-import { createMapeoServer } from '../src/server.js'
+import {
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+} from '../src/client.js'
+import { createComapeoCoreServer } from '../src/server.js'
 
 import { FakeManager } from './fake-manager.js'
 
@@ -10,15 +13,15 @@ import { FakeManager } from './fake-manager.js'
 export function setup(t, manager = new FakeManager()) {
   const { port1, port2 } = new MessageChannel()
 
-  const server = createMapeoServer(/** @type {any} */ (manager), port1)
-  const client = createMapeoClient(port2)
+  const server = createComapeoCoreServer(/** @type {any} */ (manager), port1)
+  const client = createComapeoCoreClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(async () => {
     server.close()
-    await closeMapeoClient(client)
+    await closeComapeoCoreClient(client)
     port1.close()
     port2.close()
   })

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -8,8 +8,11 @@ import { KeyManager } from '@mapeo/crypto'
 import { MapeoManager } from '@comapeo/core'
 import Fastify from 'fastify'
 
-import { createMapeoClient, closeMapeoClient } from '../src/client.js'
-import { createMapeoServer } from '../src/server.js'
+import {
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+} from '../src/client.js'
+import { createComapeoCoreServer } from '../src/server.js'
 
 const require = createRequire(import.meta.url)
 
@@ -43,15 +46,15 @@ test('end-to-end against a real MapeoManager', async (t) => {
   })
 
   const { port1, port2 } = new MessageChannel()
-  const server = createMapeoServer(manager, port1)
-  const client = createMapeoClient(port2)
+  const server = createComapeoCoreServer(manager, port1)
+  const client = createComapeoCoreClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(async () => {
     server.close()
-    await closeMapeoClient(client)
+    await closeComapeoCoreClient(client)
     fs.rmSync(dbDir, { recursive: true, force: true })
     fs.rmSync(coreDir, { recursive: true, force: true })
     port1.close()

--- a/tests/multiplexing.js
+++ b/tests/multiplexing.js
@@ -2,25 +2,28 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  createMapeoClient,
-  closeMapeoClient,
-  createAppRpcClient,
-  closeAppRpcClient,
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+  createComapeoServicesClient,
+  closeComapeoServicesClient,
 } from '../src/client.js'
-import { createMapeoServer, createAppRpcServer } from '../src/server.js'
+import {
+  createComapeoCoreServer,
+  createComapeoServicesServer,
+} from '../src/server.js'
 
 import { FakeManager } from './fake-manager.js'
 
 const MOCK_BASE_URL = 'http://localhost:3000'
 
 // The whole reason this module exists on top of rpc-reflector: several logical
-// RPC endpoints (manager, the mapeo-rpc helper channel, per-project channels,
-// and app-rpc) are multiplexed over a SINGLE message port, distinguished by a
-// subchannel id. These tests drive the manager and app-rpc endpoints over one
-// shared port and assert there's no cross-talk.
-test('Manager and App RPC coexist on a single shared message port', async (t) => {
-  // The manager server's per-project router and the app-rpc server share this
-  // port; app-rpc traffic must not be mistaken for an unroutable message.
+// RPC endpoints (manager, the project-routing helper channel, per-project
+// channels, and the services API) are multiplexed over a SINGLE message port,
+// distinguished by a subchannel id. These tests drive the core and services
+// endpoints over one shared port and assert there's no cross-talk.
+test('Core and services clients coexist on a single shared message port', async (t) => {
+  // The core server's per-project router and the services server share this
+  // port; services traffic must not be mistaken for an unroutable message.
   /** @type {string[]} */
   const noise = []
   const originalWarn = console.warn
@@ -37,8 +40,8 @@ test('Manager and App RPC coexist on a single shared message port', async (t) =>
   const { port1, port2 } = new MessageChannel()
 
   const manager = new FakeManager()
-  /** @type {import('../src/server.js').RpcApi} */
-  const appApi = {
+  /** @type {import('../src/server.js').ComapeoServicesApi} */
+  const services = {
     mapServer: {
       async getBaseUrl() {
         return MOCK_BASE_URL
@@ -46,37 +49,40 @@ test('Manager and App RPC coexist on a single shared message port', async (t) =>
     },
   }
 
-  const mapeoServer = createMapeoServer(/** @type {any} */ (manager), port1)
-  const appServer = createAppRpcServer(appApi, port1)
+  const coreServer = createComapeoCoreServer(
+    /** @type {any} */ (manager),
+    port1,
+  )
+  const servicesServer = createComapeoServicesServer(services, port1)
 
-  const mapeoClient = createMapeoClient(port2)
-  const appClient = createAppRpcClient(port2)
+  const coreClient = createComapeoCoreClient(port2)
+  const servicesClient = createComapeoServicesClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(async () => {
-    mapeoServer.close()
-    appServer.close()
-    await closeMapeoClient(mapeoClient)
-    closeAppRpcClient(appClient)
+    coreServer.close()
+    servicesServer.close()
+    await closeComapeoCoreClient(coreClient)
+    closeComapeoServicesClient(servicesClient)
     port1.close()
     port2.close()
   })
 
-  const projectId = await mapeoClient.createProject({ name: 'mapeo' })
-  const baseUrl = await appClient.mapServer.getBaseUrl()
+  const projectId = await coreClient.createProject({ name: 'mapeo' })
+  const baseUrl = await servicesClient.mapServer.getBaseUrl()
 
   assert.ok(projectId)
   assert.equal(baseUrl, MOCK_BASE_URL)
 
   // Interleave concurrent traffic across both endpoints (and a per-project
   // channel) on the same port; each call must land on its own handler.
-  const project = await mapeoClient.getProject(projectId)
+  const project = await coreClient.getProject(projectId)
   const [settings, url, projects] = await Promise.all([
     project.$getProjectSettings(),
-    appClient.mapServer.getBaseUrl(),
-    mapeoClient.listProjects(),
+    servicesClient.mapServer.getBaseUrl(),
+    coreClient.listProjects(),
   ])
 
   assert.equal(settings.name, 'mapeo')
@@ -94,8 +100,8 @@ test('Closing one endpoint on a shared port leaves the other working', async (t)
   const { port1, port2 } = new MessageChannel()
 
   const manager = new FakeManager()
-  /** @type {import('../src/server.js').RpcApi} */
-  const appApi = {
+  /** @type {import('../src/server.js').ComapeoServicesApi} */
+  const services = {
     mapServer: {
       async getBaseUrl() {
         return MOCK_BASE_URL
@@ -103,29 +109,32 @@ test('Closing one endpoint on a shared port leaves the other working', async (t)
     },
   }
 
-  const mapeoServer = createMapeoServer(/** @type {any} */ (manager), port1)
-  const appServer = createAppRpcServer(appApi, port1)
+  const coreServer = createComapeoCoreServer(
+    /** @type {any} */ (manager),
+    port1,
+  )
+  const servicesServer = createComapeoServicesServer(services, port1)
 
-  const mapeoClient = createMapeoClient(port2)
-  const appClient = createAppRpcClient(port2)
+  const coreClient = createComapeoCoreClient(port2)
+  const servicesClient = createComapeoServicesClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(async () => {
-    mapeoServer.close()
-    await closeMapeoClient(mapeoClient)
+    coreServer.close()
+    await closeComapeoCoreClient(coreClient)
     port1.close()
     port2.close()
   })
 
-  // Tear down only the app-rpc endpoint. The manager endpoint shares the same
+  // Tear down only the services endpoint. The core endpoint shares the same
   // port and must be unaffected.
-  appServer.close()
-  closeAppRpcClient(appClient)
+  servicesServer.close()
+  closeComapeoServicesClient(servicesClient)
 
-  const projectId = await mapeoClient.createProject({ name: 'mapeo' })
+  const projectId = await coreClient.createProject({ name: 'mapeo' })
   assert.ok(projectId)
-  const projects = await mapeoClient.listProjects()
+  const projects = await coreClient.listProjects()
   assert.equal(projects.length, 1)
 })

--- a/tests/services.js
+++ b/tests/services.js
@@ -1,27 +1,30 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { createAppRpcClient, closeAppRpcClient } from '../src/client.js'
-import { createAppRpcServer } from '../src/server.js'
+import {
+  createComapeoServicesClient,
+  closeComapeoServicesClient,
+} from '../src/client.js'
+import { createComapeoServicesServer } from '../src/server.js'
 import { RpcChannelClosedError } from '../src/errors.js'
 
 /**
  * @param {import('node:test').TestContext} t
- * @param {import('../src/server.js').RpcApi} [rpcApi]
+ * @param {import('../src/server.js').ComapeoServicesApi} [servicesApi]
  */
-function setup(t, rpcApi) {
+function setup(t, servicesApi) {
   const { port1, port2 } = new MessageChannel()
 
-  const api = rpcApi || createMockRpcApi()
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
+  const api = servicesApi || createMockServices()
+  const server = createComapeoServicesServer(api, port1)
+  const client = createComapeoServicesClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(() => {
     server.close()
-    closeAppRpcClient(client)
+    closeComapeoServicesClient(client)
     port1.close()
     port2.close()
   })
@@ -31,8 +34,8 @@ function setup(t, rpcApi) {
 
 const MOCK_BASE_URL = 'http://localhost:3000'
 
-/** @returns {import('../src/server.js').RpcApi} */
-function createMockRpcApi() {
+/** @returns {import('../src/server.js').ComapeoServicesApi} */
+function createMockServices() {
   return {
     mapServer: {
       async getBaseUrl() {
@@ -42,7 +45,7 @@ function createMockRpcApi() {
   }
 }
 
-test('AppRpc client can call server method and get result', async (t) => {
+test('Services client can call server method and get result', async (t) => {
   const { client } = setup(t)
 
   const result = await client.mapServer.getBaseUrl()
@@ -50,10 +53,10 @@ test('AppRpc client can call server method and get result', async (t) => {
   assert.equal(result, MOCK_BASE_URL)
 })
 
-test('AppRpc concurrent calls resolve correctly', async (t) => {
+test('Services concurrent calls resolve correctly', async (t) => {
   let callCount = 0
 
-  /** @type {import('../src/server.js').RpcApi} */
+  /** @type {import('../src/server.js').ComapeoServicesApi} */
   const api = {
     mapServer: {
       async getBaseUrl() {
@@ -77,9 +80,9 @@ test('AppRpc concurrent calls resolve correctly', async (t) => {
   assert.equal(results[2], MOCK_BASE_URL + '-3')
 })
 
-test('AppRpc server method errors are propagated to client', async (t) => {
+test('Services server method errors are propagated to client', async (t) => {
   const expectedError = new Error('Error')
-  /** @type {import('../src/server.js').RpcApi} */
+  /** @type {import('../src/server.js').ComapeoServicesApi} */
   const api = {
     mapServer: {
       async getBaseUrl() {
@@ -93,16 +96,16 @@ test('AppRpc server method errors are propagated to client', async (t) => {
   await assert.rejects(() => client.mapServer.getBaseUrl(), expectedError)
 })
 
-test('AppRpc client calls fail after server closes', async (t) => {
+test('Services client calls fail after server closes', async (t) => {
   const { port1, port2 } = new MessageChannel()
   t.after(() => {
     port1.close()
     port2.close()
   })
 
-  const api = createMockRpcApi()
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
+  const api = createMockServices()
+  const server = createComapeoServicesServer(api, port1)
+  const client = createComapeoServicesClient(port2)
 
   port1.start()
   port2.start()
@@ -112,19 +115,19 @@ test('AppRpc client calls fail after server closes', async (t) => {
   assert.equal(result, MOCK_BASE_URL)
 
   server.close()
-  closeAppRpcClient(client)
+  closeComapeoServicesClient(client)
 
   await assert.rejects(() => client.mapServer.getBaseUrl(), {
     code: RpcChannelClosedError.code,
   })
 })
 
-test('AppRpc server close is idempotent', async (t) => {
+test('Services server close is idempotent', async (t) => {
   const { port1, port2 } = new MessageChannel()
 
-  const api = createMockRpcApi()
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2)
+  const api = createMockServices()
+  const server = createComapeoServicesServer(api, port1)
+  const client = createComapeoServicesClient(port2)
 
   port1.start()
   port2.start()
@@ -133,7 +136,7 @@ test('AppRpc server close is idempotent', async (t) => {
   server.close()
   server.close()
 
-  closeAppRpcClient(client)
+  closeComapeoServicesClient(client)
 
   t.after(() => {
     port1.close()

--- a/tests/timeout.js
+++ b/tests/timeout.js
@@ -1,14 +1,17 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { createAppRpcClient, closeAppRpcClient } from '../src/client.js'
-import { createAppRpcServer } from '../src/server.js'
+import {
+  createComapeoServicesClient,
+  closeComapeoServicesClient,
+} from '../src/client.js'
+import { createComapeoServicesServer } from '../src/server.js'
 import { RpcTimeoutError } from '../src/errors.js'
 
 test('Calls reject with RpcTimeoutError when the server never responds', async (t) => {
   const { port1, port2 } = new MessageChannel()
 
-  /** @type {import('../src/server.js').RpcApi} */
+  /** @type {import('../src/server.js').ComapeoServicesApi} */
   const api = {
     mapServer: {
       // Never settles, so the only way the call can complete is the client
@@ -17,15 +20,15 @@ test('Calls reject with RpcTimeoutError when the server never responds', async (
     },
   }
 
-  const server = createAppRpcServer(api, port1)
-  const client = createAppRpcClient(port2, { timeout: 50 })
+  const server = createComapeoServicesServer(api, port1)
+  const client = createComapeoServicesClient(port2, { timeout: 50 })
 
   port1.start()
   port2.start()
 
   t.after(() => {
     server.close()
-    closeAppRpcClient(client)
+    closeComapeoServicesClient(client)
     port1.close()
     port2.close()
   })

--- a/tests/transport.js
+++ b/tests/transport.js
@@ -1,8 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { createMapeoClient, closeMapeoClient } from '../src/client.js'
-import { createMapeoServer } from '../src/server.js'
+import {
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+} from '../src/client.js'
+import { createComapeoCoreServer } from '../src/server.js'
 
 import { setup } from './helpers.js'
 import { FakeManager } from './fake-manager.js'
@@ -10,14 +13,21 @@ import { FakeManager } from './fake-manager.js'
 test('Malformed and unroutable messages are ignored and the client keeps working', async (t) => {
   const { client, port2 } = setup(t)
 
+  // A prefixed-but-unroutable id is logged via console.error; foreign and
+  // malformed messages should produce no log at all, so capture both streams.
   /** @type {string[]} */
-  const warnings = []
+  const logs = []
   const originalWarn = console.warn
+  const originalError = console.error
   console.warn = (/** @type {unknown[]} */ ...args) => {
-    warnings.push(String(args[0]))
+    logs.push(String(args[0]))
+  }
+  console.error = (/** @type {unknown[]} */ ...args) => {
+    logs.push(String(args[0]))
   }
   t.after(() => {
     console.warn = originalWarn
+    console.error = originalError
   })
 
   // Posting on port2 delivers to the server's port. None of these should throw
@@ -26,10 +36,15 @@ test('Malformed and unroutable messages are ignored and the client keeps working
   port2.postMessage(42)
   port2.postMessage(null)
   port2.postMessage({ no: 'id or message' })
-  // Well-formed envelope, but for an instance id the server never opened.
-  // Posted twice to exercise the warn-once dedupe.
-  port2.postMessage({ id: 'project-999:42', message: { value: 'whatever' } })
-  port2.postMessage({ id: 'project-999:42', message: { value: 'whatever' } })
+  // Well-formed envelope without our channel prefix: a foreign sender sharing
+  // the port. Dropped silently — not our traffic, so no warning.
+  port2.postMessage({ id: 'someone-elses-channel', message: { value: 'x' } })
+  // Well-formed envelope carrying our prefix but for an instance id the server
+  // never opened — a genuine routing miss. Posted twice to exercise the
+  // warn-once dedupe.
+  const unknownId = '@@comapeo/project/project-999:42'
+  port2.postMessage({ id: unknownId, message: { value: 'whatever' } })
+  port2.postMessage({ id: unknownId, message: { value: 'whatever' } })
 
   // Let the messages flush through the event loop.
   await new Promise((resolve) => setImmediate(resolve))
@@ -40,26 +55,29 @@ test('Malformed and unroutable messages are ignored and the client keeps working
   const settings = await project.$getProjectSettings()
   assert.equal(settings.name, 'mapeo')
 
-  // The unroutable id is warned about exactly once (deduped), not errored;
-  // the structurally-invalid messages are dropped without any warning.
-  const unrecognised = warnings.filter((w) => w.includes('project-999:42'))
+  // The prefixed-but-unroutable id is logged exactly once (deduped).
+  const unrecognised = logs.filter((w) => w.includes('project-999:42'))
   assert.equal(unrecognised.length, 1)
+  // The foreign (unprefixed) envelope and the structurally-invalid messages
+  // are dropped without any log.
+  const foreign = logs.filter((w) => w.includes('someone-elses-channel'))
+  assert.equal(foreign.length, 0)
 })
 
-test('createMapeoServer().close() is idempotent', async (t) => {
+test('createComapeoCoreServer().close() is idempotent', async (t) => {
   const { port1, port2 } = new MessageChannel()
 
-  const server = createMapeoServer(
+  const server = createComapeoCoreServer(
     /** @type {any} */ (new FakeManager()),
     port1,
   )
-  const client = createMapeoClient(port2)
+  const client = createComapeoCoreClient(port2)
 
   port1.start()
   port2.start()
 
   t.after(async () => {
-    await closeMapeoClient(client)
+    await closeComapeoCoreClient(client)
     port1.close()
     port2.close()
   })


### PR DESCRIPTION
Renames the two public RPC surfaces for clarity and to align with the CoMapeo product name.

Public API (breaking):
- `createMapeoClient`/`Server` -> `createComapeoCoreClient`/`Server`
- `createAppRpcClient`/`Server` -> `createComapeoServicesClient`/`Server`
- `closeMapeoClient` -> `closeComapeoCoreClient`, `closeAppRpcClient` -> `closeComapeoServicesClient`
- typedefs renamed (`ClientApi<...>` types carry `Client`); `RpcApi` -> `ComapeoServicesApi`
- internal `MapeoRpcApi` class -> `ProjectRoutingApi`

The "services" API is the surface the host app implements (the map server today, blob and icon servers later) and that `@comapeo/core-react` consumes — the old "app RPC" name read as infrastructure rather than a contract.

Channel ids now share a `@@comapeo/` prefix. The server uses it to distinguish its own traffic from a foreign sender on a shared port: unprefixed ids are dropped silently, and a prefixed-but-unknown id (a genuine routing bug) is logged once via `console.error`.

Also merges the README behaviour/contract docs and notes that the changelog is no longer maintained (release notes live in GitHub Releases).

BREAKING CHANGE: all public exports are renamed and the channel id strings changed, so client and server must be upgraded together.

All checks (eslint, types, prettier) and the 35-test suite pass.