### PR TITLE
fix: clear project refs on close event

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,4 @@
 import { createClient } from 'rpc-reflector/client.js'
-import pDefer from 'p-defer'
 
 import {
   MANAGER_CHANNEL_ID,
@@ -84,8 +83,23 @@ const CLOSE = Symbol('close')
  * @returns {ComapeoCoreClientApi}
  */
 export function createComapeoCoreClient(messagePort, opts = {}) {
-  /** @type {Map<string, Promise<ClientApi<MapeoProject>>>} */
-  const projectClientPromises = new Map()
+  /**
+   * projectPublicId → wrapper bound to a specific instance id. Only returned
+   * after the server confirms that instance is still current — the server
+   * can close a project without the client asking (e.g. `leaveProject`).
+   * @type {Map<string, {
+   *   instanceId: string,
+   *   wrapper: ClientApi<MapeoProject>,
+   * }>}
+   */
+  const currentProjectClients = new Map()
+
+  /**
+   * projectPublicId → in-flight `getProject`. Dedupes concurrent calls;
+   * entries are removed on settle so later calls re-validate.
+   * @type {Map<string, Promise<ClientApi<MapeoProject>>>}
+   */
+  const pendingProjectClients = new Map()
 
   /**
    * The rpc-reflector client + SubChannel pair for every currently-open
@@ -126,16 +140,13 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
           // closing project clients. `openProjectClients` is populated
           // synchronously after `assertProjectExists` resolves, so any
           // creation that hasn't settled yet isn't in the registry.
-          await Promise.allSettled(projectClientPromises.values())
+          await Promise.allSettled(pendingProjectClients.values())
 
           for (const entry of openProjectClients) {
             createClient.close(entry.client)
             entry.channel.close()
           }
           openProjectClients.clear()
-          // `projectClientPromises` is intentionally NOT cleared: a
-          // `getProject(id)` after close returns the cached wrapper, whose
-          // method calls reject with `ManagerClosedError`.
 
           // Closed last so in-flight `assertProjectExists` calls awaited
           // above can complete rather than reject.
@@ -172,35 +183,45 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
     // close — whether or not this id was fetched (and cached) earlier.
     if (clientClosed) throw new ClientClosedError()
 
-    const existingClientPromise = projectClientPromises.get(projectPublicId)
+    const pending = pendingProjectClients.get(projectPublicId)
+    if (pending) return pending
 
-    if (existingClientPromise) return existingClientPromise
-
-    /** @type {import('p-defer').DeferredPromise<ClientApi<MapeoProject>>} */
-    const deferred = pDefer()
-
-    projectClientPromises.set(projectPublicId, deferred.promise)
-
-    // Attach a no-op handler so that if the deferred rejects below before
-    // any other caller has awaited it, we don't get an unhandled rejection.
-    // (Removing the cache entry on failure means concurrent callers may
-    // never see deferred.promise.)
-    deferred.promise.catch(() => {})
-
-    /** @type {string} */
-    let instanceId
+    const promise = resolveProjectClient(projectPublicId)
+    pendingProjectClients.set(projectPublicId, promise)
     try {
-      instanceId =
-        await projectRoutingClient.assertProjectExists(projectPublicId)
-    } catch (err) {
-      // Failed to open the project — drop the cached promise so a
-      // subsequent getProject() call can retry instead of getting back
-      // the same rejected promise.
-      projectClientPromises.delete(projectPublicId)
-      deferred.reject(err)
-      throw err
+      return await promise
+    } finally {
+      pendingProjectClients.delete(projectPublicId)
     }
+  }
 
+  /**
+   * Return the cached wrapper only if the server confirms its instance id is
+   * still current; otherwise build a fresh one. The server evicts its routing
+   * entry synchronously on close, so this is correct even before the close
+   * event reaches this client.
+   *
+   * @param {string} projectPublicId
+   * @returns {Promise<ClientApi<MapeoProject>>}
+   */
+  async function resolveProjectClient(projectPublicId) {
+    const instanceId =
+      await projectRoutingClient.assertProjectExists(projectPublicId)
+
+    const current = currentProjectClients.get(projectPublicId)
+    if (current && current.instanceId === instanceId) return current.wrapper
+
+    const wrapper = createProjectClientWrapper(projectPublicId, instanceId)
+    currentProjectClients.set(projectPublicId, { instanceId, wrapper })
+    return wrapper
+  }
+
+  /**
+   * @param {string} projectPublicId
+   * @param {string} instanceId
+   * @returns {ClientApi<MapeoProject>}
+   */
+  function createProjectClientWrapper(projectPublicId, instanceId) {
     // Per-project messages are scoped to the current open instance, not the
     // project's public id. If this project is closed and re-opened later,
     // `assertProjectExists` returns a different instance id, so the new
@@ -215,8 +236,9 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
     openProjectClients.add(registryEntry)
 
     // Wrap projectClient to intercept `close`: after the wire close settles,
-    // tear down the local client + channel — rejecting any in-flight calls —
-    // and evict the cache entry so a subsequent `getProject(id)` re-opens.
+    // tear down the local client + channel — rejecting any in-flight calls.
+    // Cache eviction is in the 'close' listener below, which also covers
+    // manager-initiated closes.
     // Further method calls on this wrapper reject with `ProjectClosedError`.
     // The close promise is cached so repeated `close()` calls return the
     // same result instead of failing on the already-closed channel. All
@@ -255,10 +277,14 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
     })
     wrappedProjectClient.once('close', () => {
       closed = true
-      projectClientPromises.delete(projectPublicId)
+      // A late close event must not evict a newer wrapper cached for the
+      // re-opened instance.
+      const current = currentProjectClients.get(projectPublicId)
+      if (current?.wrapper === wrappedProjectClient) {
+        currentProjectClients.delete(projectPublicId)
+      }
       openProjectClients.delete(registryEntry)
     })
-    deferred.resolve(wrappedProjectClient)
     return wrappedProjectClient
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -240,9 +240,6 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
               try {
                 await target.close()
               } finally {
-                closed = true
-                projectClientPromises.delete(projectPublicId)
-                openProjectClients.delete(registryEntry)
                 createClient.close(projectClient)
                 projectChannel.close()
               }
@@ -255,6 +252,11 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
         }
         return Reflect.get(target, prop, receiver)
       },
+    })
+    wrappedProjectClient.once('close', () => {
+      closed = true
+      projectClientPromises.delete(projectPublicId)
+      openProjectClients.delete(registryEntry)
     })
     deferred.resolve(wrappedProjectClient)
     return wrappedProjectClient

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -77,11 +77,10 @@ test('handle manager initiating the close', async (t) => {
   const clientProject = await client.getProject(projectId)
   const rawProject = await manager.getProject(projectId)
 
-  // TODO: Error, the close event isnt done on the client side after this finishes
   // This simulates the project being closed through other means like leaveProject
   await rawProject.close()
 
-  assert.rejects(() => clientProject.$getProjectSettings(), {
+  await assert.rejects(() => clientProject.$getProjectSettings(), {
     code: ProjectClosedError.code,
   })
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -13,6 +13,7 @@ import {
   closeComapeoCoreClient,
 } from '../src/client.js'
 import { createComapeoCoreServer } from '../src/server.js'
+import { ProjectClosedError } from '../src/errors.js'
 
 const require = createRequire(import.meta.url)
 
@@ -32,7 +33,67 @@ const clientMigrationsFolder = path.join(
 // of the suite runs against an in-memory fake (see fake-manager.js); this one
 // proves the IPC wiring matches the real manager/project API shape and that
 // real values round-trip over the channel.
+
+/**
+ * @param {import('node:test').TestContext} t
+ */
 test('end-to-end against a real MapeoManager', async (t) => {
+  const { server, client } = setup(t)
+  // Manager methods round-trip.
+  const projectId = await client.createProject({ name: 'mapeo' })
+  assert.ok(projectId)
+
+  const listed = await client.listProjects()
+  assert.equal(listed.length, 1)
+
+  // Per-project subchannel: settings, a nested-namespace write + read back,
+  // then close.
+  const project = await client.getProject(projectId)
+
+  const settings = await project.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+
+  const obs = await project.observation.create({
+    schemaName: 'observation',
+    attachments: [],
+    tags: {},
+  })
+  const readBack = await project.observation.getByDocId(obs.docId)
+  assert.equal(readBack.docId, obs.docId)
+
+  await project.close()
+})
+
+/**
+ * @param {import('node:test').TestContext} t
+ */
+test('handle manager initiating the close', async (t) => {
+  const { server, client, manager } = setup(t)
+  // Manager methods round-trip.
+
+  const projectId = await client.createProject({ name: 'mapeo' })
+  assert.ok(projectId)
+
+  const clientProject = await client.getProject(projectId)
+  const rawProject = await manager.getProject(projectId)
+
+  // TODO: Error, the close event isnt done on the client side after this finishes
+  // This simulates the project being closed through other means like leaveProject
+  await rawProject.close()
+
+  assert.rejects(() => clientProject.$getProjectSettings(), {
+    code: ProjectClosedError.code,
+  })
+
+  const reOpened = await client.getProject(projectId)
+
+  await reOpened.$getProjectSettings()
+})
+
+/**
+ * @param {import('node:test').TestContext} t
+ */
+function setup(t) {
   const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'comapeo-ipc-it-db-'))
   const coreDir = fs.mkdtempSync(path.join(os.tmpdir(), 'comapeo-ipc-it-core-'))
 
@@ -61,27 +122,5 @@ test('end-to-end against a real MapeoManager', async (t) => {
     port2.close()
   })
 
-  // Manager methods round-trip.
-  const projectId = await client.createProject({ name: 'mapeo' })
-  assert.ok(projectId)
-
-  const listed = await client.listProjects()
-  assert.equal(listed.length, 1)
-
-  // Per-project subchannel: settings, a nested-namespace write + read back,
-  // then close.
-  const project = await client.getProject(projectId)
-
-  const settings = await project.$getProjectSettings()
-  assert.equal(settings.name, 'mapeo')
-
-  const obs = await project.observation.create({
-    schemaName: 'observation',
-    attachments: [],
-    tags: {},
-  })
-  const readBack = await project.observation.getByDocId(obs.docId)
-  assert.equal(readBack.docId, obs.docId)
-
-  await project.close()
-})
+  return { server, client, manager }
+}

--- a/tests/project-close.js
+++ b/tests/project-close.js
@@ -168,6 +168,59 @@ test('When the server closes the project, client calls on the wrapper reject', a
   await reopenedServerProject.close()
 })
 
+// The next two tests pin recovery from a manager-initiated close — what
+// `MapeoManager.addProject` does to a previously-left project when a
+// re-invite is accepted (digidem/comapeo-mobile#2042). The cached client
+// wrapper for the closed instance must not keep being handed out by
+// `getProject` once the project can be re-opened.
+
+test('After a manager-initiated close is observed, getProject returns a fresh working instance', async (t) => {
+  const { client, serverManager } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+  const project = await client.getProject(projectId)
+
+  // Deliberately not node:events `once()`: its cleanup calls
+  // `removeListener` on the wrapper after the close event, which a closed
+  // wrapper may reject synchronously.
+  const closeObserved = new Promise((resolve) => {
+    project.once('close', resolve)
+  })
+  // Round-trip so the 'close' subscription is registered server-side
+  // (FIFO channel) before the close below emits.
+  await project.$getProjectSettings()
+
+  const serverProject = await serverManager.getProject(projectId)
+  await serverProject.close()
+  await closeObserved
+
+  const reOpened = await client.getProject(projectId)
+  const settings = await reOpened.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+  assert.notEqual(
+    reOpened,
+    project,
+    'getProject after an observed close should return a fresh wrapper',
+  )
+})
+
+test('getProject returns a working instance immediately after a manager-initiated close', async (t) => {
+  const { client, serverManager } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+  await client.getProject(projectId)
+
+  const serverProject = await serverManager.getProject(projectId)
+  await serverProject.close()
+
+  // The close notification has not reached the client yet, so its cached
+  // wrapper still looks open. The server already knows the project is
+  // closed (it updated its routing state during close() above), so to
+  // return a working instance here getProject must ask the server rather
+  // than trust its cache.
+  const reOpened = await client.getProject(projectId)
+  const settings = await reOpened.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+})
+
 test('A method call posted before close completes still resolves', async (t) => {
   const { client } = setup(t)
   const projectId = await client.createProject({ name: 'mapeo' })


### PR DESCRIPTION
The project can close for other reasons like `manager.leaveProject`. We should be robust against different reasons for project close being added over time by listening to the `close` event.