### PR TITLE
fix: bump optic releas workflow to 4.12.4 to fix syntax error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: nearform-actions/optic-release-automation-action@9e3518763346efacba15d729d0faaa4cbd8fdd52 # v4.12.3
+      - uses: nearform-actions/optic-release-automation-action@08642f7889f3bb519fb69ce2c3bf58e4f900c018 # v4.12.4
         with:
           commit-message: 'Release {version}'
           sync-semver-tags: false


### PR DESCRIPTION
fixes syntax error during releases due to latest node/npm version having breaking changes.