### PR TITLE
feat: add transport-reset handling for server restarts

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,7 +6,11 @@ import {
   SERVICES_ID,
   SubChannel,
 } from './lib/sub-channel.js'
-import { ClientClosedError, ProjectClosedError } from './errors.js'
+import {
+  ClientClosedError,
+  ProjectClosedError,
+  TransportClosedError,
+} from './errors.js'
 
 /** @import { ClientApi, MessagePortLike } from 'rpc-reflector' */
 /** @import { MapeoProject, MapeoManager } from '@comapeo/core' */
@@ -75,6 +79,7 @@ function createClosedProxy(makeError) {
  * >} ComapeoCoreClientApi */
 
 const CLOSE = Symbol('close')
+const TRANSPORT_RESET = Symbol('transportReset')
 
 /**
  * @param {MessagePortLike} messagePort
@@ -108,6 +113,7 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
    * @type {Set<{
    *   client: ClientApi<MapeoProject>,
    *   channel: SubChannel,
+   *   hardClose: (error: Error) => void,
    * }>}
    */
   const openProjectClients = new Set()
@@ -128,6 +134,36 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
   // surface `ManagerClosedError` instead of rpc-reflector's `ChannelClosed`.
   let clientClosed = false
   const managerClosedProxy = createClosedProxy(() => new ClientClosedError())
+
+  // Bumped on every transport reset so a `getProject` whose routing response
+  // arrived just before the reset cannot cache a wrapper bound to the dead
+  // server (see `resolveProjectClient`).
+  let resetGeneration = 0
+
+  function handleTransportReset() {
+    if (clientClosed) return
+    resetGeneration++
+
+    // Fail in-flight calls fast with a distinguishable, retryable error
+    // instead of leaving them to hit the per-call timeout.
+    createClient.rejectPending(managerClient, new TransportClosedError())
+    createClient.rejectPending(projectRoutingClient, new TransportClosedError())
+    // The restarted server has lost every event subscription; replay them.
+    createClient.resubscribe(managerClient)
+    createClient.resubscribe(projectRoutingClient)
+
+    // Project instance ids are minted by a counter that restarts with the
+    // server, so a restarted server can mint an id equal to the one a cached
+    // wrapper is bound to — the instance-id currency check in
+    // `resolveProjectClient` could then falsely pass. Hard-close every
+    // wrapper and drop the cache so `getProject` always builds a fresh
+    // wrapper against the new server.
+    for (const entry of openProjectClients) {
+      entry.hardClose(new TransportClosedError())
+    }
+    openProjectClients.clear()
+    currentProjectClients.clear()
+  }
 
   const client = new Proxy(managerClient, {
     get(target, prop, receiver) {
@@ -155,6 +191,10 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
 
           clientClosed = true
         }
+      }
+
+      if (prop === TRANSPORT_RESET) {
+        return handleTransportReset
       }
 
       if (prop === 'getProject') {
@@ -205,8 +245,14 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
    * @returns {Promise<ClientApi<MapeoProject>>}
    */
   async function resolveProjectClient(projectPublicId) {
+    const generation = resetGeneration
     const instanceId =
       await projectRoutingClient.assertProjectExists(projectPublicId)
+
+    // A reset can land between the routing response arriving and this
+    // continuation running; a wrapper minted now would be bound to the dead
+    // server, so reject like any other call in flight during the reset.
+    if (generation !== resetGeneration) throw new TransportClosedError()
 
     const current = currentProjectClients.get(projectPublicId)
     if (current && current.instanceId === instanceId) return current.wrapper
@@ -232,9 +278,6 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
     const projectClient = createClient(projectChannel, opts)
     projectChannel.start()
 
-    const registryEntry = { client: projectClient, channel: projectChannel }
-    openProjectClients.add(registryEntry)
-
     // Wrap projectClient to intercept `close`: after the wire close settles,
     // tear down the local client + channel — rejecting any in-flight calls.
     // Cache eviction is in the 'close' listener below, which also covers
@@ -254,6 +297,24 @@ export function createComapeoCoreClient(messagePort, opts = {}) {
     const closedProxy = createClosedProxy(() =>
       closed ? new ProjectClosedError() : new ClientClosedError(),
     )
+
+    const registryEntry = {
+      client: projectClient,
+      channel: projectChannel,
+      // Local-only teardown for a transport reset: the server this instance
+      // belonged to is gone, so there is no wire close to await. Stale
+      // references then behave like a closed project (`ProjectClosedError`),
+      // and `close()` on them resolves like an already-closed project.
+      hardClose: (/** @type {Error} */ error) => {
+        createClient.rejectPending(projectClient, error)
+        createClient.close(projectClient)
+        projectChannel.close()
+        closed = true
+        closePromise = Promise.resolve()
+      },
+    }
+    openProjectClients.add(registryEntry)
+
     const wrappedProjectClient = new Proxy(projectClient, {
       get(target, prop, receiver) {
         if (prop === 'close') {
@@ -299,6 +360,33 @@ export async function closeComapeoCoreClient(client) {
 }
 
 /**
+ * Notify the core client that the underlying transport dropped and has
+ * reconnected to a restarted server (e.g. Android killed and restarted the
+ * foreground service hosting the server). Call after the transport is back
+ * up. This:
+ *
+ * - rejects every call that was in flight with `TransportClosedError`
+ *   (`code: 'RPC_TRANSPORT_CLOSED'`), so callers can fail fast and retry
+ *   instead of waiting for the per-call timeout;
+ * - re-sends event subscriptions for the manager, which the restarted server
+ *   had lost;
+ * - hard-closes every open project client and drops the project cache, so a
+ *   later `getProject` builds a fresh wrapper against the new server. Stale
+ *   project references held by the app behave like closed projects
+ *   (`ProjectClosedError`). A `getProject` in flight during the reset
+ *   rejects with `TransportClosedError`.
+ *
+ * No-op after `closeComapeoCoreClient`.
+ *
+ * @param {ComapeoCoreClientApi} client client created with `createComapeoCoreClient`
+ * @returns {void}
+ */
+export function notifyCoreClientTransportReset(client) {
+  // @ts-expect-error
+  return client[TRANSPORT_RESET]()
+}
+
+/**
  * @typedef {ClientApi<ComapeoServicesApi>} ComapeoServicesClientApi
  */
 
@@ -328,4 +416,19 @@ export function createComapeoServicesClient(messagePort, opts = {}) {
  */
 export function closeComapeoServicesClient(servicesClient) {
   createClient.close(servicesClient)
+}
+
+/**
+ * Notify the services client that the underlying transport dropped and has
+ * reconnected to a restarted server: rejects every call that was in flight
+ * with `TransportClosedError` (`code: 'RPC_TRANSPORT_CLOSED'`) and re-sends
+ * event subscriptions the restarted server had lost. No-op after
+ * `closeComapeoServicesClient`.
+ *
+ * @param {ComapeoServicesClientApi} servicesClient client created with `createComapeoServicesClient`
+ * @returns {void}
+ */
+export function notifyServicesClientTransportReset(servicesClient) {
+  createClient.rejectPending(servicesClient, new TransportClosedError())
+  createClient.resubscribe(servicesClient)
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -17,6 +17,20 @@ export const ProjectClosedError = createErrorClass({
 })
 
 /**
+ * Rejected client-side into calls that were in flight when the underlying
+ * transport dropped (e.g. the process hosting the server was killed and
+ * restarted). Distinguishable from a real failure or a timeout: the call
+ * never completed on the server's side of the connection, so a read is safe
+ * to retry once the transport has reconnected.
+ */
+export const TransportClosedError = createErrorClass({
+  code: 'RPC_TRANSPORT_CLOSED',
+  message:
+    'Transport closed: the connection to the server dropped while the call was in flight',
+  status: 503,
+})
+
+/**
  * Thrown client-side when a method is called after the CoMapeo core client
  * (the whole IPC client) has been closed via `closeComapeoCoreClient`.
  */

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 export {
   createComapeoCoreClient,
   closeComapeoCoreClient,
+  notifyCoreClientTransportReset,
   createComapeoServicesClient,
   closeComapeoServicesClient,
+  notifyServicesClientTransportReset,
 } from './client.js'
 export {
   createComapeoCoreServer,

--- a/tests/transport-reset.js
+++ b/tests/transport-reset.js
@@ -1,0 +1,248 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import pDefer from 'p-defer'
+
+import {
+  createComapeoCoreClient,
+  closeComapeoCoreClient,
+  notifyCoreClientTransportReset,
+  createComapeoServicesClient,
+  closeComapeoServicesClient,
+  notifyServicesClientTransportReset,
+} from '../src/client.js'
+import {
+  createComapeoCoreServer,
+  createComapeoServicesServer,
+} from '../src/server.js'
+import { ProjectClosedError, TransportClosedError } from '../src/errors.js'
+
+import { setup } from './helpers.js'
+import { FakeManager } from './fake-manager.js'
+
+/**
+ * Simulate the server process dying and restarting while the client (and the
+ * message port it holds) stays alive — the Android foreground-service restart
+ * case: close the old server and serve a fresh manager over the same port.
+ *
+ * @param {import('node:test').TestContext} t
+ * @param {ReturnType<typeof setup>['server']} oldServer
+ * @param {MessagePort} serverPort
+ */
+function restartServer(t, oldServer, serverPort) {
+  oldServer.close()
+  const newManager = new FakeManager()
+  const newServer = createComapeoCoreServer(
+    /** @type {any} */ (newManager),
+    serverPort,
+  )
+  t.after(() => newServer.close())
+  return { newManager, newServer }
+}
+
+test('Reset rejects in-flight manager and getProject calls with TransportClosedError', async (t) => {
+  const { client, server } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+
+  // With the server gone, these calls can never be answered.
+  server.close()
+  const inFlightManagerCall = client.listProjects()
+  const inFlightGetProject = client.getProject(projectId)
+
+  notifyCoreClientTransportReset(client)
+
+  await assert.rejects(() => inFlightManagerCall, {
+    code: TransportClosedError.code,
+  })
+  await assert.rejects(() => inFlightGetProject, {
+    code: TransportClosedError.code,
+  })
+})
+
+test('Reset rejects in-flight project method calls with TransportClosedError', async (t) => {
+  const { client, server } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+  const project = await client.getProject(projectId)
+
+  server.close()
+  const inFlightProjectCall = project.$getProjectSettings()
+
+  notifyCoreClientTransportReset(client)
+
+  await assert.rejects(() => inFlightProjectCall, {
+    code: TransportClosedError.code,
+  })
+})
+
+test('Manager event subscriptions are replayed to the restarted server', async (t) => {
+  const { client, server, port1 } = setup(t)
+
+  /** @type {import('p-defer').DeferredPromise<unknown>} */
+  const deferred = pDefer()
+  client.on('local-peers', (peers) => deferred.resolve(peers))
+  await client.listProjects()
+
+  const { newManager } = restartServer(t, server, port1)
+  notifyCoreClientTransportReset(client)
+  // Round-trip barrier so the replayed subscribe message has been processed.
+  await client.listProjects()
+
+  const peers = [{ deviceId: 'peer-a' }]
+  newManager.emit('local-peers', peers)
+
+  assert.deepEqual(await deferred.promise, peers)
+})
+
+test('Stale project wrapper is not reused after reset, even when the new server mints the same instance id', async (t) => {
+  const { client, server, port1 } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+  const staleProject = await client.getProject(projectId)
+  await staleProject.$getProjectSettings()
+
+  const { newManager } = restartServer(t, server, port1)
+  notifyCoreClientTransportReset(client)
+
+  // The fresh manager mints the same project id ('project-1') and the fresh
+  // server's instance counter restarts, so `assertProjectExists` returns an
+  // instance id identical to the one the stale wrapper is bound to — the
+  // cache must have been dropped for this to return a working wrapper.
+  const newProjectId = await client.createProject({ name: 'mapeo' })
+  assert.equal(newProjectId, projectId, 'test setup: same project id reminted')
+
+  const freshProject = await client.getProject(projectId)
+  assert.notEqual(
+    freshProject,
+    staleProject,
+    'getProject returns a fresh wrapper, not the stale one',
+  )
+  const settings = await freshProject.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+
+  // Only the fresh manager's project should be reachable.
+  assert.equal(newManager.getProjectCallCount.get(projectId), 1)
+})
+
+test('Stale project references behave like closed projects after reset', async (t) => {
+  const { client, server, port1 } = setup(t)
+  const projectId = await client.createProject({ name: 'mapeo' })
+  const staleProject = await client.getProject(projectId)
+
+  restartServer(t, server, port1)
+  notifyCoreClientTransportReset(client)
+
+  await assert.rejects(() => staleProject.$getProjectSettings(), {
+    code: ProjectClosedError.code,
+  })
+  await assert.rejects(
+    () =>
+      staleProject.observation.create({
+        schemaName: 'observation',
+        attachments: [],
+        tags: {},
+      }),
+    { code: ProjectClosedError.code },
+  )
+  // `close()` on a stale reference resolves like an already-closed project.
+  await staleProject.close()
+})
+
+test('getProject that is in flight during reset rejects, and a retry returns a working client', async (t) => {
+  const manager = new FakeManager()
+  /** @type {import('p-defer').DeferredPromise<never>} */
+  const gate = pDefer()
+  // Hold `getProject` open server-side so the routing call is still in
+  // flight when the reset lands.
+  const originalGetProject = manager.getProject.bind(manager)
+  manager.getProject = () => gate.promise
+
+  const { client, server, port1 } = setup(t, manager)
+  const projectId = await client.createProject({ name: 'mapeo' })
+
+  const inFlightGetProject = client.getProject(projectId)
+
+  const { newManager } = restartServer(t, server, port1)
+  notifyCoreClientTransportReset(client)
+
+  await assert.rejects(() => inFlightGetProject, {
+    code: TransportClosedError.code,
+  })
+  manager.getProject = originalGetProject
+
+  // The dedupe map entry for the rejected call must not poison the retry.
+  await client.createProject({ name: 'mapeo' })
+  const project = await client.getProject(projectId)
+  const settings = await project.$getProjectSettings()
+  assert.equal(settings.name, 'mapeo')
+  assert.ok(newManager.getProjectCallCount.get(projectId))
+})
+
+test('Reset is a no-op after the client is closed', async (t) => {
+  const { port1, port2 } = new MessageChannel()
+  const manager = new FakeManager()
+  const server = createComapeoCoreServer(/** @type {any} */ (manager), port1)
+  const client = createComapeoCoreClient(port2)
+  port1.start()
+  port2.start()
+  t.after(() => {
+    server.close()
+    port1.close()
+    port2.close()
+  })
+
+  await closeComapeoCoreClient(client)
+
+  assert.doesNotThrow(() => notifyCoreClientTransportReset(client))
+})
+
+test('Services client reset rejects in-flight calls and replays subscriptions', async (t) => {
+  const { port1, port2 } = new MessageChannel()
+  t.after(() => {
+    port1.close()
+    port2.close()
+  })
+
+  const makeApi = () =>
+    Object.assign(new EventEmitter(), {
+      mapServer: {
+        async getBaseUrl() {
+          return 'http://localhost:3000'
+        },
+      },
+    })
+
+  const oldServer = createComapeoServicesServer(makeApi(), port1)
+  const client = createComapeoServicesClient(port2)
+  port1.start()
+  port2.start()
+  t.after(() => closeComapeoServicesClient(client))
+
+  /** @type {unknown[]} */
+  const received = []
+  const eventfulClient = /** @type {any} */ (client)
+  eventfulClient.on('service-event', (/** @type {unknown} */ e) =>
+    received.push(e),
+  )
+  await client.mapServer.getBaseUrl()
+
+  oldServer.close()
+  const inFlightCall = client.mapServer.getBaseUrl()
+
+  // Restart: a fresh services server (with a fresh emitter) on the same port.
+  const newApi = makeApi()
+  const newServer = createComapeoServicesServer(newApi, port1)
+  t.after(() => newServer.close())
+
+  notifyServicesClientTransportReset(client)
+
+  await assert.rejects(() => inFlightCall, {
+    code: TransportClosedError.code,
+  })
+
+  // Round-trip barrier so the replayed subscribe has been processed.
+  await client.mapServer.getBaseUrl()
+  newApi.emit('service-event', 'payload')
+  // Let the forwarded event flush through the port.
+  await client.mapServer.getBaseUrl()
+
+  assert.deepEqual(received, ['payload'])
+})


### PR DESCRIPTION
@comapeo/core-react-native runs the CoMapeo backend in an Android foreground service. Android's low-memory killer can kill and restart that service while the app keeps running; the Unix-socket transport reconnects, but the restarted server has lost every event subscription, calls that were in flight hang until they time out, and cached per-project clients are bound to a server that no longer exists. This PR gives the transport owner the hooks to recover. Desktop/Electron consumers are unaffected (additive API).

New exports:

`TransportClosedError` (`errors.js`) with a stable `code` of `'RPC_TRANSPORT_CLOSED'` — rejected into calls that were in flight when the transport dropped, so callers can distinguish "backend restarted; a read is safe to retry" from a real failure or a timeout.

`notifyCoreClientTransportReset(client)` — call after the transport has reconnected. It rejects pending calls on the manager and project-routing clients with `TransportClosedError` and replays their event subscriptions (via rpc-reflector's new `createClient.rejectPending` / `createClient.resubscribe`), then hard-closes every open project client (reject pending, `createClient.close`, SubChannel close) and drops `openProjectClients` / `currentProjectClients`, so a later `getProject` builds a fresh wrapper against the new server. No-op after `closeComapeoCoreClient`.

`notifyServicesClientTransportReset(servicesClient)` — the same reject-pending + resubscribe treatment for the (single, bare) services client.

The hard close of project wrappers is forced by the instance-id scheme: instance ids are minted by a deterministic counter (`projectId:++n`) that restarts with the server, so a restarted server can mint the *same* id a cached wrapper is bound to, and the "is the cached wrapper still current" check in `resolveProjectClient` would falsely pass. Stale project references held by the app behave like closed projects afterwards (they reuse the existing closed-proxy behaviour and reject with `ProjectClosedError`, whose "get a fresh reference via `getProject`" remedy is exactly right here); `close()` on a stale reference resolves. A `getProject` in flight during the reset rejects with `TransportClosedError` (including the narrow race where the routing response arrived just before the reset, guarded by a reset generation counter), and a retry returns a working client.

Depends on digidem/rpc-reflector#52 — this PR should merge after that one lands and is released, followed by bumping the `rpc-reflector` range here (the committed `package.json` still points at the current release, so CI will fail on the new-API tests until then).